### PR TITLE
Allow to specifc OrgID in ProviderConfig

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -27,8 +27,8 @@ type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
 
-	// OrgId of the organization in which to reconcile resources.
-	OrgId string `json:"orgId"`
+	// OrgID of the organization in which to reconcile resources.
+	OrgID int `json:"orgID,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -26,6 +26,9 @@ import (
 type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
+
+	// OrgId of the organization in which to reconcile resources.
+	OrgId string `json:"orgId"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/examples/providerconfig/providerconfig.yaml
+++ b/examples/providerconfig/providerconfig.yaml
@@ -3,6 +3,7 @@ kind: ProviderConfig
 metadata:
   name: grafana-provider
 spec:
+  orgId: 1
   credentials:
     source: Secret
     secretRef:

--- a/examples/providerconfig/providerconfig.yaml
+++ b/examples/providerconfig/providerconfig.yaml
@@ -3,7 +3,7 @@ kind: ProviderConfig
 metadata:
   name: grafana-provider
 spec:
-  orgId: 1
+  orgID: 1
   credentials:
     source: Secret
     secretRef:

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -44,11 +44,12 @@ const (
 
 	// Grafana non-sensitive environment variable names
 
-	envOrgId = "GRAFANA_ORG_ID"
+	envOrgID = "GRAFANA_ORG_ID"
 )
 
 const (
-	fmtEnvVar = "%s=%s"
+	fmtEnvVar        = "%s=%s"
+	fmtEnvVarFromInt = "%s=%d"
 
 	// error messages
 	errNoProviderConfig     = "no providerConfigRef provided"
@@ -103,12 +104,12 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			ps.Configuration[keyOrgID] = orgID
 		}
 
-		// default to  OrgId 1 if not specified
+		// default to  OrgID 1 if not specified
 		ps.Configuration[keyOrgID] = 1
-		orgid := pc.DeepCopy().Spec.OrgId
-		if len(orgid) > 0 {
+		orgid := pc.Spec.OrgID
+		if orgid > 0 {
 			ps.Configuration[keyOrgID] = orgid
-			ps.Env = append(ps.Env, fmt.Sprintf(fmtEnvVar, envOrgId, orgid))
+			ps.Env = append(ps.Env, fmt.Sprintf(fmtEnvVarFromInt, envOrgID, orgid))
 		}
 
 		// set environment variables for sensitive provider configuration

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -95,9 +95,6 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		if url, ok := grafanaCreds[keyURL]; ok {
 			ps.Configuration[keyURL] = url
 		}
-		if orgID, ok := grafanaCreds[keyOrgID]; ok {
-			ps.Configuration[keyOrgID] = orgID
-		}
 
 		// default to  OrgID 1 if not specified
 		ps.Configuration[keyOrgID] = 1

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -41,15 +41,10 @@ const (
 	envAuth          = "GRAFANA_AUTH"
 	envCloudAPIKey   = "GRAFANA_CLOUD_API_URL"
 	envSMAccessToken = "GRAFANA_SM_ACCESS_TOKEN"
-
-	// Grafana non-sensitive environment variable names
-
-	envOrgID = "GRAFANA_ORG_ID"
 )
 
 const (
-	fmtEnvVar        = "%s=%s"
-	fmtEnvVarFromInt = "%s=%d"
+	fmtEnvVar = "%s=%s"
 
 	// error messages
 	errNoProviderConfig     = "no providerConfigRef provided"
@@ -109,7 +104,6 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		orgid := pc.Spec.OrgID
 		if orgid > 0 {
 			ps.Configuration[keyOrgID] = orgid
-			ps.Env = append(ps.Env, fmt.Sprintf(fmtEnvVarFromInt, envOrgID, orgid))
 		}
 
 		// set environment variables for sensitive provider configuration

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -41,6 +41,10 @@ const (
 	envAuth          = "GRAFANA_AUTH"
 	envCloudAPIKey   = "GRAFANA_CLOUD_API_URL"
 	envSMAccessToken = "GRAFANA_SM_ACCESS_TOKEN"
+
+	// Grafana non-sensitive environment variable names
+
+	envOrgId = "GRAFANA_ORG_ID"
 )
 
 const (
@@ -97,6 +101,14 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		}
 		if orgID, ok := grafanaCreds[keyOrgID]; ok {
 			ps.Configuration[keyOrgID] = orgID
+		}
+
+		// default to  OrgId 1 if not specified
+		ps.Configuration[keyOrgID] = 1
+		orgid := pc.DeepCopy().Spec.OrgId
+		if len(orgid) > 0 {
+			ps.Configuration[keyOrgID] = orgid
+			ps.Env = append(ps.Env, fmt.Sprintf(fmtEnvVar, envOrgId, orgid))
 		}
 
 		// set environment variables for sensitive provider configuration

--- a/package/crds/grafana.jet.crossplane.io_providerconfigs.yaml
+++ b/package/crds/grafana.jet.crossplane.io_providerconfigs.yaml
@@ -99,12 +99,11 @@ spec:
                 required:
                 - source
                 type: object
-              orgId:
-                description: OrgId of the organization in which to reconcile resources.
-                type: string
+              orgID:
+                description: OrgID of the organization in which to reconcile resources.
+                type: integer
             required:
             - credentials
-            - orgId
             type: object
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.

--- a/package/crds/grafana.jet.crossplane.io_providerconfigs.yaml
+++ b/package/crds/grafana.jet.crossplane.io_providerconfigs.yaml
@@ -99,8 +99,12 @@ spec:
                 required:
                 - source
                 type: object
+              orgId:
+                description: OrgId of the organization in which to reconcile resources.
+                type: string
             required:
             - credentials
+            - orgId
             type: object
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The ProviderConfig was extended by an additional optioal property `orgID`, which _can_ be used to specify the Grafana Organization by the corresponding ID of it, in order to create ProviderConfig specific to a organization.
This is achieved by moving the `orgID` from the referenced secret's payload to `ProviderConfig.Spec`, resulting in increased flexibility, by eliminating the need to construct the secret's JSON payload dynamically.

If no `orgID` is specified, the value defaults to `1`.

Example without `orgID`:
```
apiVersion: grafana.jet.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: grafana-provider
spec:
  credentials:
    source: Secret
    secretRef:
      name: grafana-creds
      namespace: crossplane
      key: credentials
```

Example with `orgID`:
```
apiVersion: grafana.jet.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: grafana-provider
spec:
  orgID: 1
  credentials:
    source: Secret
    secretRef:
      name: grafana-creds
      namespace: crossplane
      key: credentials
```

Fixes #2

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9


A `ProviderConfig` without `orgID` was created and a `Folder` resource has been provisioned.
It was succssfully created and reconciled inside the Grafana Organization with ID `1`.

The `ProviderConfig` was updated with `orgID: 2` and a `Folder` resource has been provisioned.
It was succssfully created and reconciled inside the Grafana Organization with ID `2`.