### PR TITLE
feat(grafana_data_source): added passwordSecretRef again

### DIFF
--- a/apis/oss/v1alpha1/zz_datasource_types.go
+++ b/apis/oss/v1alpha1/zz_datasource_types.go
@@ -51,6 +51,10 @@ type DataSourceParameters struct {
 	// +kubebuilder:validation:Required
 	Name *string `json:"name" tf:"name,omitempty"`
 
+	// Use secure_json_data_encoded.password instead. Defaults to “.
+	// +kubebuilder:validation:Optional
+	PasswordSecretRef *v1.SecretKeySelector `json:"passwordSecretRef,omitempty" tf:"-"`
+
 	// Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 	// +kubebuilder:validation:Optional
 	SecureJSONDataEncodedSecretRef *v1.SecretKeySelector `json:"secureJsonDataEncodedSecretRef,omitempty" tf:"-"`

--- a/apis/oss/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/oss/v1alpha1/zz_generated.deepcopy.go
@@ -647,6 +647,11 @@ func (in *DataSourceParameters) DeepCopyInto(out *DataSourceParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PasswordSecretRef != nil {
+		in, out := &in.PasswordSecretRef, &out.PasswordSecretRef
+		*out = new(v1.SecretKeySelector)
+		**out = **in
+	}
 	if in.SecureJSONDataEncodedSecretRef != nil {
 		in, out := &in.SecureJSONDataEncodedSecretRef, &out.SecureJSONDataEncodedSecretRef
 		*out = new(v1.SecretKeySelector)

--- a/apis/oss/v1alpha1/zz_generated_terraformed.go
+++ b/apis/oss/v1alpha1/zz_generated_terraformed.go
@@ -242,7 +242,7 @@ func (mg *DataSource) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this DataSource
 func (tr *DataSource) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"http_headers": "spec.forProvider.httpHeadersSecretRef", "secure_json_data_encoded": "spec.forProvider.secureJsonDataEncodedSecretRef"}
+	return map[string]string{"http_headers": "spec.forProvider.httpHeadersSecretRef", "password": "spec.forProvider.passwordSecretRef", "secure_json_data_encoded": "spec.forProvider.secureJsonDataEncodedSecretRef"}
 }
 
 // GetObservation of this DataSource

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -67,7 +67,6 @@ func Configure(p *ujconfig.Provider) {
 	})
 	p.AddResourceConfigurator("grafana_data_source", func(r *ujconfig.Resource) {
 		delete(r.TerraformResource.Schema, "basic_auth_password") // Deprecated
-		delete(r.TerraformResource.Schema, "password")            // Deprecated
 		delete(r.TerraformResource.Schema, "json_data")           // Deprecated
 		delete(r.TerraformResource.Schema, "secure_json_data")    // Deprecated
 	})

--- a/package/crds/oss.grafana.crossplane.io_datasources.yaml
+++ b/package/crds/oss.grafana.crossplane.io_datasources.yaml
@@ -107,6 +107,24 @@ spec:
                   name:
                     description: A unique name for the data source.
                     type: string
+                  passwordSecretRef:
+                    description: Use secure_json_data_encoded.password instead. Defaults
+                      to “.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   secureJsonDataEncodedSecretRef:
                     description: Serialized JSON string containing the secure json
                       data. This attribute can be used to pass secure configuration


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
we used the old terrajet grafana provider and migrated to the upjet implementation - and `passwordSecretRef`is missing - so we added `password` for `grafana_data_source` again.
for crossplane eco-system its much more easier with `password` field - because we can directly use the generated connectionSecrets from rds for example - is this an option for this deprecated field ?  we can't find why this field is deprecated in terraform provider

```
---
apiVersion: oss.grafana.crossplane.io/v1alpha1
kind: DataSource
metadata:
  name: sonarqube-postgresql
spec:
  forProvider:
    accessMode: proxy
    name: test
    type: postgres
    databaseName: sonarqube
    url: sonarqube.xxxx.eu-central-1.rds.amazonaws.com:5432
    username: user123
    passwordSecretRef: 
      key: password
      name: sonarqube-dbinstance
      namespace: sonarqube 
    jsonDataEncoded: |
      {
      "connMaxLifetime": "14400",
      "maxIdleConns": "2",
      "maxOpenConns": "0",
      "postgresVersion": "1000",
      "sslMode": "disable",
      "timeInterval": "1m",
      "timescaledb": "false"
      }
  providerConfigRef:
    name: example
```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                                        READY   SYNCED   EXTERNAL-NAME   AGE
datasource.oss.grafana.crossplane.io/sonarqube-postgresql                   True    True    16              11m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
