### PR TITLE
Escape Terraform interpolation

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -172,6 +172,7 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "FolderSelector",
 			Extractor:         SelfPackagePath + ".UIDExtractor()",
 		}
+		r.InitializerFns = append(r.InitializerFns, createDashboardConfigInitializer)
 	})
 	p.AddResourceConfigurator("grafana_dashboard_permission", func(r *ujconfig.Resource) {
 		delete(r.TerraformResource.Schema, "dashboard_id") // Deprecated

--- a/config/grafana/dashboard_init.go
+++ b/config/grafana/dashboard_init.go
@@ -1,0 +1,57 @@
+package grafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createDashboardConfigInitializer(client client.Client) managed.Initializer {
+	return &dashboardConfigInitializer{
+		kube: client,
+	}
+}
+
+// Based on the Tagger: https://github.com/crossplane/upjet/blob/v1.1.0/pkg/config/resource.go#L268
+type dashboardConfigInitializer struct {
+	kube client.Client
+}
+
+// Replaces ${ with $${ to avoid TF interpolation
+func (i *dashboardConfigInitializer) Initialize(ctx context.Context, mg resource.Managed) error {
+	paved, err := fieldpath.PaveObject(mg)
+	if err != nil {
+		return err
+	}
+	v, err := paved.GetString("spec.forProvider.configJSON")
+	if err != nil {
+		return fmt.Errorf("could not get configJSON: %w", err)
+	}
+	if err := paved.SetString("spec.forProvider.configJSON", replaceInterpolation(v)); err != nil {
+		return fmt.Errorf("could not set configJSON: %w", err)
+	}
+	pavedByte, err := paved.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("could not marshal modified dashboard spec into JSON: %w", err)
+	}
+	if err := json.Unmarshal(pavedByte, mg); err != nil {
+		return fmt.Errorf("could not unmarshal modified dashboard spec into managed resource interface: %w", err)
+	}
+	if err := i.kube.Update(ctx, mg); err != nil {
+		return fmt.Errorf("could not update managed resource: %w", err)
+	}
+	return nil
+}
+
+// Replaces ${ with $${ to avoid TF interpolation
+// If a string is already escaped, it should not be escaped again
+func replaceInterpolation(s string) string {
+	replaced := strings.ReplaceAll(s, "${", "$${")
+	return strings.ReplaceAll(replaced, "$$${", "$${") // Unescape already escaped strings
+}

--- a/config/grafana/dashboard_init_test.go
+++ b/config/grafana/dashboard_init_test.go
@@ -1,0 +1,46 @@
+package grafana
+
+import "testing"
+
+func TestReplaceInterpolation(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no interpolation",
+			input:    "no interpolation",
+			expected: "no interpolation",
+		},
+		{
+			name:     "interpolation",
+			input:    "interpolation ${}",
+			expected: "interpolation $${}",
+		},
+		{
+			name:     "escaped interpolation",
+			input:    "escaped interpolation $${}",
+			expected: "escaped interpolation $${}",
+		},
+		{
+			name:     "multiple interpolations",
+			input:    "multiple ${} interpolations ${}",
+			expected: "multiple $${} interpolations $${}",
+		},
+		{
+			name:     "multiple escaped interpolations",
+			input:    "interpolation $${} with escaped $${}",
+			expected: "interpolation $${} with escaped $${}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := replaceInterpolation(tc.input)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/controller/oss/dashboard/zz_controller.go
+++ b/internal/controller/oss/dashboard/zz_controller.go
@@ -32,6 +32,9 @@ import (
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.Dashboard_GroupVersionKind.String())
 	var initializers managed.InitializerChain
+	for _, i := range o.Provider.Resources["grafana_dashboard"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))


### PR DESCRIPTION
Replaces `${` with `$${` so that Terraform doesn't complain. But also ignores `$${` for retro-compatibility. Users (us included) have already put workarounds and we don't want to introduce a breaking change here

Closes https://github.com/grafana/crossplane-provider-grafana/issues/59
