### PR TITLE
Add stack ref for access policy identifier

### DIFF
--- a/apis/cloud/v1alpha1/zz_accesspolicy_types.go
+++ b/apis/cloud/v1alpha1/zz_accesspolicy_types.go
@@ -128,10 +128,21 @@ type RealmInitParameters struct {
 
 	// (String) The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
+	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:refFieldName=StackRef
+	// +crossplane:generate:reference:selectorFieldName=StackSelector
 	Identifier *string `json:"identifier,omitempty" tf:"identifier,omitempty"`
 
 	// (Block Set) (see below for nested schema)
 	LabelPolicy []LabelPolicyInitParameters `json:"labelPolicy,omitempty" tf:"label_policy,omitempty"`
+
+	// Reference to a Stack in cloud to populate identifier.
+	// +kubebuilder:validation:Optional
+	StackRef *v1.Reference `json:"stackRef,omitempty" tf:"-"`
+
+	// Selector for a Stack in cloud to populate identifier.
+	// +kubebuilder:validation:Optional
+	StackSelector *v1.Selector `json:"stackSelector,omitempty" tf:"-"`
 
 	// (String) Whether a policy applies to a Cloud org or a specific stack. Should be one of org or stack.
 	// Whether a policy applies to a Cloud org or a specific stack. Should be one of `org` or `stack`.
@@ -156,12 +167,23 @@ type RealmParameters struct {
 
 	// (String) The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
+	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:refFieldName=StackRef
+	// +crossplane:generate:reference:selectorFieldName=StackSelector
 	// +kubebuilder:validation:Optional
-	Identifier *string `json:"identifier" tf:"identifier,omitempty"`
+	Identifier *string `json:"identifier,omitempty" tf:"identifier,omitempty"`
 
 	// (Block Set) (see below for nested schema)
 	// +kubebuilder:validation:Optional
 	LabelPolicy []LabelPolicyParameters `json:"labelPolicy,omitempty" tf:"label_policy,omitempty"`
+
+	// Reference to a Stack in cloud to populate identifier.
+	// +kubebuilder:validation:Optional
+	StackRef *v1.Reference `json:"stackRef,omitempty" tf:"-"`
+
+	// Selector for a Stack in cloud to populate identifier.
+	// +kubebuilder:validation:Optional
+	StackSelector *v1.Selector `json:"stackSelector,omitempty" tf:"-"`
 
 	// (String) Whether a policy applies to a Cloud org or a specific stack. Should be one of org or stack.
 	// Whether a policy applies to a Cloud org or a specific stack. Should be one of `org` or `stack`.

--- a/apis/cloud/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cloud/v1alpha1/zz_generated.deepcopy.go
@@ -993,6 +993,16 @@ func (in *RealmInitParameters) DeepCopyInto(out *RealmInitParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.StackRef != nil {
+		in, out := &in.StackRef, &out.StackRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.StackSelector != nil {
+		in, out := &in.StackSelector, &out.StackSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(string)
@@ -1056,6 +1066,16 @@ func (in *RealmParameters) DeepCopyInto(out *RealmParameters) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.StackRef != nil {
+		in, out := &in.StackRef, &out.StackRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.StackSelector != nil {
+		in, out := &in.StackSelector, &out.StackSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type

--- a/apis/cloud/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cloud/v1alpha1/zz_generated.resolvers.go
@@ -13,6 +13,53 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ResolveReferences of this AccessPolicy.
+func (mg *AccessPolicy) ResolveReferences(ctx context.Context, c client.Reader) error {
+	r := reference.NewAPIResolver(c, mg)
+
+	var rsp reference.ResolutionResponse
+	var err error
+
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Realm); i3++ {
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Realm[i3].Identifier),
+			Extract:      reference.ExternalName(),
+			Reference:    mg.Spec.ForProvider.Realm[i3].StackRef,
+			Selector:     mg.Spec.ForProvider.Realm[i3].StackSelector,
+			To: reference.To{
+				List:    &StackList{},
+				Managed: &Stack{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.ForProvider.Realm[i3].Identifier")
+		}
+		mg.Spec.ForProvider.Realm[i3].Identifier = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.ForProvider.Realm[i3].StackRef = rsp.ResolvedReference
+
+	}
+	for i3 := 0; i3 < len(mg.Spec.InitProvider.Realm); i3++ {
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Realm[i3].Identifier),
+			Extract:      reference.ExternalName(),
+			Reference:    mg.Spec.InitProvider.Realm[i3].StackRef,
+			Selector:     mg.Spec.InitProvider.Realm[i3].StackSelector,
+			To: reference.To{
+				List:    &StackList{},
+				Managed: &Stack{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.InitProvider.Realm[i3].Identifier")
+		}
+		mg.Spec.InitProvider.Realm[i3].Identifier = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.InitProvider.Realm[i3].StackRef = rsp.ResolvedReference
+
+	}
+
+	return nil
+}
+
 // ResolveReferences of this AccessPolicyToken.
 func (mg *AccessPolicyToken) ResolveReferences(ctx context.Context, c client.Reader) error {
 	r := reference.NewAPIResolver(c, mg)

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -91,6 +91,13 @@ func Configure(p *ujconfig.Provider) {
 			return conn, nil
 		}
 	})
+	p.AddResourceConfigurator("grafana_cloud_access_policy", func(r *ujconfig.Resource) {
+		r.References["realm.identifier"] = ujconfig.Reference{
+			TerraformName:     "grafana_cloud_stack",
+			RefFieldName:      "StackRef",
+			SelectorFieldName: "StackSelector",
+		}
+	})
 	p.AddResourceConfigurator("grafana_cloud_access_policy_token", func(r *ujconfig.Resource) {
 		r.References["access_policy_id"] = ujconfig.Reference{
 			TerraformName:     "grafana_cloud_access_policy",

--- a/examples-generated/cloud/v1alpha1/accesspolicy.yaml
+++ b/examples-generated/cloud/v1alpha1/accesspolicy.yaml
@@ -11,9 +11,11 @@ spec:
     displayName: My Policy
     name: my-policy
     realm:
-    - identifier: ${data.grafana_cloud_organization.current.id}
-      labelPolicy:
+    - labelPolicy:
       - selector: '{namespace="default"}'
+      stackSelector:
+        matchLabels:
+          testing.upbound.io/example-name: grafana_cloud_organization
       type: org
     region: us
     scopes:

--- a/examples-generated/cloud/v1alpha1/accesspolicytoken.yaml
+++ b/examples-generated/cloud/v1alpha1/accesspolicytoken.yaml
@@ -31,9 +31,11 @@ spec:
     displayName: My Policy
     name: my-policy
     realm:
-    - identifier: ${data.grafana_cloud_organization.current.id}
-      labelPolicy:
+    - labelPolicy:
       - selector: '{namespace="default"}'
+      stackSelector:
+        matchLabels:
+          testing.upbound.io/example-name: grafana_cloud_organization
       type: org
     region: us
     scopes:

--- a/examples-generated/sm/v1alpha1/installation.yaml
+++ b/examples-generated/sm/v1alpha1/installation.yaml
@@ -32,7 +32,9 @@ spec:
     name: metric-publisher-for-sm
     provider: ${grafana.cloud}
     realm:
-    - identifier: ${grafana_cloud_stack.sm_stack.id}
+    - stackSelector:
+        matchLabels:
+          testing.upbound.io/example-name: sm_stack
       type: stack
     region: ${var.cloud_region}
     scopes:

--- a/package/crds/cloud.grafana.crossplane.io_accesspolicies.yaml
+++ b/package/crds/cloud.grafana.crossplane.io_accesspolicies.yaml
@@ -105,6 +105,80 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        stackRef:
+                          description: Reference to a Stack in cloud to populate identifier.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        stackSelector:
+                          description: Selector for a Stack in cloud to populate identifier.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         type:
                           description: |-
                             (String) Whether a policy applies to a Cloud org or a specific stack. Should be one of org or stack.
@@ -169,6 +243,80 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        stackRef:
+                          description: Reference to a Stack in cloud to populate identifier.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        stackSelector:
+                          description: Selector for a Stack in cloud to populate identifier.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         type:
                           description: |-
                             (String) Whether a policy applies to a Cloud org or a specific stack. Should be one of org or stack.


### PR DESCRIPTION
Allows users to refer a stack that they've created with Crossplane in their access policy at `spec.forProvider.realm.stackRef` rather than `spec.forProvider.realm.identifier` which takes in a stack ID
