### PR TITLE
Access Policy: Fix access policy reference

### DIFF
--- a/apis/alerting/v1alpha1/zz_generated.resolvers.go
+++ b/apis/alerting/v1alpha1/zz_generated.resolvers.go
@@ -150,7 +150,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ContactPoint),
-		Extract:      grafana.NameExtractor(),
+		Extract:      grafana.FieldExtractor("name"),
 		Reference:    mg.Spec.ForProvider.ContactPointRef,
 		Selector:     mg.Spec.ForProvider.ContactPointSelector,
 		To: reference.To{
@@ -183,7 +183,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Policy); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Policy[i3].ContactPoint),
-			Extract:      grafana.NameExtractor(),
+			Extract:      grafana.FieldExtractor("name"),
 			Reference:    mg.Spec.ForProvider.Policy[i3].ContactPointRef,
 			Selector:     mg.Spec.ForProvider.Policy[i3].ContactPointSelector,
 			To: reference.To{
@@ -201,7 +201,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Policy); i3++ {
 		mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 			CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Policy[i3].MuteTimings),
-			Extract:       grafana.NameExtractor(),
+			Extract:       grafana.FieldExtractor("name"),
 			References:    mg.Spec.ForProvider.Policy[i3].MuteTimingRef,
 			Selector:      mg.Spec.ForProvider.Policy[i3].MuteTimingSelector,
 			To: reference.To{
@@ -220,7 +220,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.Policy[i3].Policy); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Policy[i3].Policy[i4].ContactPoint),
-				Extract:      grafana.NameExtractor(),
+				Extract:      grafana.FieldExtractor("name"),
 				Reference:    mg.Spec.ForProvider.Policy[i3].Policy[i4].ContactPointRef,
 				Selector:     mg.Spec.ForProvider.Policy[i3].Policy[i4].ContactPointSelector,
 				To: reference.To{
@@ -240,7 +240,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.Policy[i3].Policy); i4++ {
 			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 				CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Policy[i3].Policy[i4].MuteTimings),
-				Extract:       grafana.NameExtractor(),
+				Extract:       grafana.FieldExtractor("name"),
 				References:    mg.Spec.ForProvider.Policy[i3].Policy[i4].MuteTimingRef,
 				Selector:      mg.Spec.ForProvider.Policy[i3].Policy[i4].MuteTimingSelector,
 				To: reference.To{
@@ -261,7 +261,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 			for i5 := 0; i5 < len(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy); i5++ {
 				rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 					CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].ContactPoint),
-					Extract:      grafana.NameExtractor(),
+					Extract:      grafana.FieldExtractor("name"),
 					Reference:    mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].ContactPointRef,
 					Selector:     mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].ContactPointSelector,
 					To: reference.To{
@@ -283,7 +283,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 			for i5 := 0; i5 < len(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy); i5++ {
 				mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 					CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimings),
-					Extract:       grafana.NameExtractor(),
+					Extract:       grafana.FieldExtractor("name"),
 					References:    mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimingRef,
 					Selector:      mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimingSelector,
 					To: reference.To{
@@ -306,7 +306,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 				for i6 := 0; i6 < len(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy); i6++ {
 					rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 						CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPoint),
-						Extract:      grafana.NameExtractor(),
+						Extract:      grafana.FieldExtractor("name"),
 						Reference:    mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPointRef,
 						Selector:     mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPointSelector,
 						To: reference.To{
@@ -330,7 +330,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 				for i6 := 0; i6 < len(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy); i6++ {
 					mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 						CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimings),
-						Extract:       grafana.NameExtractor(),
+						Extract:       grafana.FieldExtractor("name"),
 						References:    mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimingRef,
 						Selector:      mg.Spec.ForProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimingSelector,
 						To: reference.To{
@@ -350,7 +350,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ContactPoint),
-		Extract:      grafana.NameExtractor(),
+		Extract:      grafana.FieldExtractor("name"),
 		Reference:    mg.Spec.InitProvider.ContactPointRef,
 		Selector:     mg.Spec.InitProvider.ContactPointSelector,
 		To: reference.To{
@@ -383,7 +383,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Policy); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Policy[i3].ContactPoint),
-			Extract:      grafana.NameExtractor(),
+			Extract:      grafana.FieldExtractor("name"),
 			Reference:    mg.Spec.InitProvider.Policy[i3].ContactPointRef,
 			Selector:     mg.Spec.InitProvider.Policy[i3].ContactPointSelector,
 			To: reference.To{
@@ -401,7 +401,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Policy); i3++ {
 		mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 			CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Policy[i3].MuteTimings),
-			Extract:       grafana.NameExtractor(),
+			Extract:       grafana.FieldExtractor("name"),
 			References:    mg.Spec.InitProvider.Policy[i3].MuteTimingRef,
 			Selector:      mg.Spec.InitProvider.Policy[i3].MuteTimingSelector,
 			To: reference.To{
@@ -420,7 +420,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 		for i4 := 0; i4 < len(mg.Spec.InitProvider.Policy[i3].Policy); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Policy[i3].Policy[i4].ContactPoint),
-				Extract:      grafana.NameExtractor(),
+				Extract:      grafana.FieldExtractor("name"),
 				Reference:    mg.Spec.InitProvider.Policy[i3].Policy[i4].ContactPointRef,
 				Selector:     mg.Spec.InitProvider.Policy[i3].Policy[i4].ContactPointSelector,
 				To: reference.To{
@@ -440,7 +440,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 		for i4 := 0; i4 < len(mg.Spec.InitProvider.Policy[i3].Policy); i4++ {
 			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 				CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Policy[i3].Policy[i4].MuteTimings),
-				Extract:       grafana.NameExtractor(),
+				Extract:       grafana.FieldExtractor("name"),
 				References:    mg.Spec.InitProvider.Policy[i3].Policy[i4].MuteTimingRef,
 				Selector:      mg.Spec.InitProvider.Policy[i3].Policy[i4].MuteTimingSelector,
 				To: reference.To{
@@ -461,7 +461,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 			for i5 := 0; i5 < len(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy); i5++ {
 				rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 					CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].ContactPoint),
-					Extract:      grafana.NameExtractor(),
+					Extract:      grafana.FieldExtractor("name"),
 					Reference:    mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].ContactPointRef,
 					Selector:     mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].ContactPointSelector,
 					To: reference.To{
@@ -483,7 +483,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 			for i5 := 0; i5 < len(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy); i5++ {
 				mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 					CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimings),
-					Extract:       grafana.NameExtractor(),
+					Extract:       grafana.FieldExtractor("name"),
 					References:    mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimingRef,
 					Selector:      mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].MuteTimingSelector,
 					To: reference.To{
@@ -506,7 +506,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 				for i6 := 0; i6 < len(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy); i6++ {
 					rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 						CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPoint),
-						Extract:      grafana.NameExtractor(),
+						Extract:      grafana.FieldExtractor("name"),
 						Reference:    mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPointRef,
 						Selector:     mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].ContactPointSelector,
 						To: reference.To{
@@ -530,7 +530,7 @@ func (mg *NotificationPolicy) ResolveReferences(ctx context.Context, c client.Re
 				for i6 := 0; i6 < len(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy); i6++ {
 					mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 						CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimings),
-						Extract:       grafana.NameExtractor(),
+						Extract:       grafana.FieldExtractor("name"),
 						References:    mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimingRef,
 						Selector:      mg.Spec.InitProvider.Policy[i3].Policy[i4].Policy[i5].Policy[i6].MuteTimingSelector,
 						To: reference.To{
@@ -561,7 +561,7 @@ func (mg *RuleGroup) ResolveReferences(ctx context.Context, c client.Reader) err
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.FolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.FolderRef,
 		Selector:     mg.Spec.ForProvider.FolderSelector,
 		To: reference.To{
@@ -593,7 +593,7 @@ func (mg *RuleGroup) ResolveReferences(ctx context.Context, c client.Reader) err
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.FolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.FolderRef,
 		Selector:     mg.Spec.InitProvider.FolderSelector,
 		To: reference.To{

--- a/apis/alerting/v1alpha1/zz_notificationpolicy_types.go
+++ b/apis/alerting/v1alpha1/zz_notificationpolicy_types.go
@@ -66,7 +66,7 @@ type NotificationPolicyInitParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The default contact point to route all unmatched notifications to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
@@ -160,7 +160,7 @@ type NotificationPolicyParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The default contact point to route all unmatched notifications to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
@@ -225,7 +225,7 @@ type PolicyInitParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
@@ -269,7 +269,7 @@ type PolicyInitParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	MuteTimings []*string `json:"muteTimings,omitempty" tf:"mute_timings,omitempty"`
@@ -375,7 +375,7 @@ type PolicyParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
@@ -425,7 +425,7 @@ type PolicyParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	// +kubebuilder:validation:Optional
@@ -447,7 +447,7 @@ type PolicyPolicyInitParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
@@ -491,7 +491,7 @@ type PolicyPolicyInitParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	MuteTimings []*string `json:"muteTimings,omitempty" tf:"mute_timings,omitempty"`
@@ -597,7 +597,7 @@ type PolicyPolicyParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
@@ -647,7 +647,7 @@ type PolicyPolicyParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	// +kubebuilder:validation:Optional
@@ -669,7 +669,7 @@ type PolicyPolicyPolicyInitParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
@@ -713,7 +713,7 @@ type PolicyPolicyPolicyInitParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	MuteTimings []*string `json:"muteTimings,omitempty" tf:"mute_timings,omitempty"`
@@ -819,7 +819,7 @@ type PolicyPolicyPolicyParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
@@ -869,7 +869,7 @@ type PolicyPolicyPolicyParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	// +kubebuilder:validation:Optional
@@ -891,7 +891,7 @@ type PolicyPolicyPolicyPolicyInitParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
@@ -935,7 +935,7 @@ type PolicyPolicyPolicyPolicyInitParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	MuteTimings []*string `json:"muteTimings,omitempty" tf:"mute_timings,omitempty"`
@@ -985,7 +985,7 @@ type PolicyPolicyPolicyPolicyParameters struct {
 	// (String) The default contact point to route all unmatched notifications to.
 	// The contact point to route notifications that match this rule to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=ContactPointRef
 	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
@@ -1035,7 +1035,7 @@ type PolicyPolicyPolicyPolicyParameters struct {
 	// (List of String) A list of mute timing names to apply to alerts that match this policy.
 	// A list of mute timing names to apply to alerts that match this policy.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.MuteTiming
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
 	// +crossplane:generate:reference:refFieldName=MuteTimingRef
 	// +crossplane:generate:reference:selectorFieldName=MuteTimingSelector
 	// +kubebuilder:validation:Optional

--- a/apis/alerting/v1alpha1/zz_rulegroup_types.go
+++ b/apis/alerting/v1alpha1/zz_rulegroup_types.go
@@ -225,7 +225,7 @@ type RuleGroupInitParameters struct {
 	// (String) The UID of the folder that the group belongs to.
 	// The UID of the folder that the group belongs to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	FolderUID *string `json:"folderUid,omitempty" tf:"folder_uid,omitempty"`
@@ -304,7 +304,7 @@ type RuleGroupParameters struct {
 	// (String) The UID of the folder that the group belongs to.
 	// The UID of the folder that the group belongs to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_accesspolicytoken_types.go
+++ b/apis/cloud/v1alpha1/zz_accesspolicytoken_types.go
@@ -18,7 +18,7 @@ type AccessPolicyTokenInitParameters struct {
 	// (String) ID of the access policy for which to create a token.
 	// ID of the access policy for which to create a token.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.AccessPolicy
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.PolicyIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("policyId")
 	// +crossplane:generate:reference:refFieldName=AccessPolicyRef
 	// +crossplane:generate:reference:selectorFieldName=AccessPolicySelector
 	AccessPolicyID *string `json:"accessPolicyId,omitempty" tf:"access_policy_id,omitempty"`
@@ -87,7 +87,7 @@ type AccessPolicyTokenParameters struct {
 	// (String) ID of the access policy for which to create a token.
 	// ID of the access policy for which to create a token.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.AccessPolicy
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.PolicyIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("policyId")
 	// +crossplane:generate:reference:refFieldName=AccessPolicyRef
 	// +crossplane:generate:reference:selectorFieldName=AccessPolicySelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_accesspolicytoken_types.go
+++ b/apis/cloud/v1alpha1/zz_accesspolicytoken_types.go
@@ -18,6 +18,7 @@ type AccessPolicyTokenInitParameters struct {
 	// (String) ID of the access policy for which to create a token.
 	// ID of the access policy for which to create a token.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.AccessPolicy
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.PolicyIDExtractor()
 	// +crossplane:generate:reference:refFieldName=AccessPolicyRef
 	// +crossplane:generate:reference:selectorFieldName=AccessPolicySelector
 	AccessPolicyID *string `json:"accessPolicyId,omitempty" tf:"access_policy_id,omitempty"`
@@ -86,6 +87,7 @@ type AccessPolicyTokenParameters struct {
 	// (String) ID of the access policy for which to create a token.
 	// ID of the access policy for which to create a token.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.AccessPolicy
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.PolicyIDExtractor()
 	// +crossplane:generate:reference:refFieldName=AccessPolicyRef
 	// +crossplane:generate:reference:selectorFieldName=AccessPolicySelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cloud/v1alpha1/zz_generated.resolvers.go
@@ -69,7 +69,7 @@ func (mg *AccessPolicyToken) ResolveReferences(ctx context.Context, c client.Rea
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.AccessPolicyID),
-		Extract:      grafana.PolicyIDExtractor(),
+		Extract:      grafana.ComputedFieldExtractor("policyId"),
 		Reference:    mg.Spec.ForProvider.AccessPolicyRef,
 		Selector:     mg.Spec.ForProvider.AccessPolicySelector,
 		To: reference.To{
@@ -85,7 +85,7 @@ func (mg *AccessPolicyToken) ResolveReferences(ctx context.Context, c client.Rea
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.AccessPolicyID),
-		Extract:      grafana.PolicyIDExtractor(),
+		Extract:      grafana.ComputedFieldExtractor("policyId"),
 		Reference:    mg.Spec.InitProvider.AccessPolicyRef,
 		Selector:     mg.Spec.InitProvider.AccessPolicySelector,
 		To: reference.To{
@@ -111,7 +111,7 @@ func (mg *PluginInstallation) ResolveReferences(ctx context.Context, c client.Re
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.ForProvider.CloudStackRef,
 		Selector:     mg.Spec.ForProvider.CloudStackSelector,
 		To: reference.To{
@@ -127,7 +127,7 @@ func (mg *PluginInstallation) ResolveReferences(ctx context.Context, c client.Re
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.InitProvider.CloudStackRef,
 		Selector:     mg.Spec.InitProvider.CloudStackSelector,
 		To: reference.To{
@@ -153,7 +153,7 @@ func (mg *StackServiceAccount) ResolveReferences(ctx context.Context, c client.R
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.ForProvider.CloudStackRef,
 		Selector:     mg.Spec.ForProvider.CloudStackSelector,
 		To: reference.To{
@@ -169,7 +169,7 @@ func (mg *StackServiceAccount) ResolveReferences(ctx context.Context, c client.R
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.InitProvider.CloudStackRef,
 		Selector:     mg.Spec.InitProvider.CloudStackSelector,
 		To: reference.To{
@@ -211,7 +211,7 @@ func (mg *StackServiceAccountToken) ResolveReferences(ctx context.Context, c cli
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.ForProvider.CloudStackRef,
 		Selector:     mg.Spec.ForProvider.CloudStackSelector,
 		To: reference.To{
@@ -243,7 +243,7 @@ func (mg *StackServiceAccountToken) ResolveReferences(ctx context.Context, c cli
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.StackSlug),
-		Extract:      grafana.CloudStackSlugExtractor(),
+		Extract:      grafana.FieldExtractor("slug"),
 		Reference:    mg.Spec.InitProvider.CloudStackRef,
 		Selector:     mg.Spec.InitProvider.CloudStackSelector,
 		To: reference.To{

--- a/apis/cloud/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cloud/v1alpha1/zz_generated.resolvers.go
@@ -69,7 +69,7 @@ func (mg *AccessPolicyToken) ResolveReferences(ctx context.Context, c client.Rea
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.AccessPolicyID),
-		Extract:      reference.ExternalName(),
+		Extract:      grafana.PolicyIDExtractor(),
 		Reference:    mg.Spec.ForProvider.AccessPolicyRef,
 		Selector:     mg.Spec.ForProvider.AccessPolicySelector,
 		To: reference.To{
@@ -85,7 +85,7 @@ func (mg *AccessPolicyToken) ResolveReferences(ctx context.Context, c client.Rea
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.AccessPolicyID),
-		Extract:      reference.ExternalName(),
+		Extract:      grafana.PolicyIDExtractor(),
 		Reference:    mg.Spec.InitProvider.AccessPolicyRef,
 		Selector:     mg.Spec.InitProvider.AccessPolicySelector,
 		To: reference.To{

--- a/apis/cloud/v1alpha1/zz_plugininstallation_types.go
+++ b/apis/cloud/v1alpha1/zz_plugininstallation_types.go
@@ -30,7 +30,7 @@ type PluginInstallationInitParameters struct {
 	// (String) The stack id to which the plugin should be installed.
 	// The stack id to which the plugin should be installed.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	StackSlug *string `json:"stackSlug,omitempty" tf:"stack_slug,omitempty"`
@@ -76,7 +76,7 @@ type PluginInstallationParameters struct {
 	// (String) The stack id to which the plugin should be installed.
 	// The stack id to which the plugin should be installed.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_stackserviceaccount_types.go
+++ b/apis/cloud/v1alpha1/zz_stackserviceaccount_types.go
@@ -37,7 +37,7 @@ type StackServiceAccountInitParameters struct {
 
 	// (String)
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	StackSlug *string `json:"stackSlug,omitempty" tf:"stack_slug,omitempty"`
@@ -91,7 +91,7 @@ type StackServiceAccountParameters struct {
 
 	// (String)
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_stackserviceaccounttoken_types.go
+++ b/apis/cloud/v1alpha1/zz_stackserviceaccounttoken_types.go
@@ -45,7 +45,7 @@ type StackServiceAccountTokenInitParameters struct {
 
 	// (String)
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	StackSlug *string `json:"stackSlug,omitempty" tf:"stack_slug,omitempty"`
@@ -110,7 +110,7 @@ type StackServiceAccountTokenParameters struct {
 
 	// (String)
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.CloudStackSlugExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("slug")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	// +kubebuilder:validation:Optional

--- a/apis/enterprise/v1alpha1/zz_generated.resolvers.go
+++ b/apis/enterprise/v1alpha1/zz_generated.resolvers.go
@@ -170,7 +170,7 @@ func (mg *Report) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DashboardRef,
 		Selector:     mg.Spec.ForProvider.DashboardSelector,
 		To: reference.To{
@@ -202,7 +202,7 @@ func (mg *Report) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DashboardRef,
 		Selector:     mg.Spec.InitProvider.DashboardSelector,
 		To: reference.To{
@@ -303,7 +303,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.RoleUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.RoleRef,
 		Selector:     mg.Spec.ForProvider.RoleSelector,
 		To: reference.To{
@@ -383,7 +383,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.RoleUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.RoleRef,
 		Selector:     mg.Spec.InitProvider.RoleSelector,
 		To: reference.To{

--- a/apis/enterprise/v1alpha1/zz_report_types.go
+++ b/apis/enterprise/v1alpha1/zz_report_types.go
@@ -77,7 +77,7 @@ type ReportInitParameters struct {
 	// (String, Deprecated) Dashboard to be sent in the report.
 	// Dashboard to be sent in the report.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	DashboardUID *string `json:"dashboardUid,omitempty" tf:"dashboard_uid,omitempty"`
@@ -223,7 +223,7 @@ type ReportParameters struct {
 	// (String, Deprecated) Dashboard to be sent in the report.
 	// Dashboard to be sent in the report.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	// +kubebuilder:validation:Optional

--- a/apis/enterprise/v1alpha1/zz_roleassignment_types.go
+++ b/apis/enterprise/v1alpha1/zz_roleassignment_types.go
@@ -41,7 +41,7 @@ type RoleAssignmentInitParameters struct {
 	// (String) Grafana RBAC role UID.
 	// Grafana RBAC role UID.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1.Role
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=RoleRef
 	// +crossplane:generate:reference:selectorFieldName=RoleSelector
 	RoleUID *string `json:"roleUid,omitempty" tf:"role_uid,omitempty"`
@@ -153,7 +153,7 @@ type RoleAssignmentParameters struct {
 	// (String) Grafana RBAC role UID.
 	// Grafana RBAC role UID.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1.Role
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=RoleRef
 	// +crossplane:generate:reference:selectorFieldName=RoleSelector
 	// +kubebuilder:validation:Optional

--- a/apis/ml/v1alpha1/zz_generated.resolvers.go
+++ b/apis/ml/v1alpha1/zz_generated.resolvers.go
@@ -23,7 +23,7 @@ func (mg *Job) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DatasourceUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DataSourceRef,
 		Selector:     mg.Spec.ForProvider.DataSourceSelector,
 		To: reference.To{
@@ -39,7 +39,7 @@ func (mg *Job) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DatasourceUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DataSourceRef,
 		Selector:     mg.Spec.InitProvider.DataSourceSelector,
 		To: reference.To{
@@ -65,7 +65,7 @@ func (mg *OutlierDetector) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DatasourceUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DataSourceRef,
 		Selector:     mg.Spec.ForProvider.DataSourceSelector,
 		To: reference.To{
@@ -81,7 +81,7 @@ func (mg *OutlierDetector) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DatasourceUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DataSourceRef,
 		Selector:     mg.Spec.InitProvider.DataSourceSelector,
 		To: reference.To{

--- a/apis/ml/v1alpha1/zz_job_types.go
+++ b/apis/ml/v1alpha1/zz_job_types.go
@@ -35,7 +35,7 @@ type JobInitParameters struct {
 
 	// The uid of the datasource to query.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DataSourceRef
 	// +crossplane:generate:reference:selectorFieldName=DataSourceSelector
 	DatasourceUID *string `json:"datasourceUid,omitempty" tf:"datasource_uid,omitempty"`
@@ -136,7 +136,7 @@ type JobParameters struct {
 
 	// The uid of the datasource to query.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DataSourceRef
 	// +crossplane:generate:reference:selectorFieldName=DataSourceSelector
 	// +kubebuilder:validation:Optional

--- a/apis/ml/v1alpha1/zz_outlierdetector_types.go
+++ b/apis/ml/v1alpha1/zz_outlierdetector_types.go
@@ -92,7 +92,7 @@ type OutlierDetectorInitParameters struct {
 
 	// The uid of the datasource to query.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DataSourceRef
 	// +crossplane:generate:reference:selectorFieldName=DataSourceSelector
 	DatasourceUID *string `json:"datasourceUid,omitempty" tf:"datasource_uid,omitempty"`
@@ -171,7 +171,7 @@ type OutlierDetectorParameters struct {
 
 	// The uid of the datasource to query.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DataSourceRef
 	// +crossplane:generate:reference:selectorFieldName=DataSourceSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_annotation_types.go
+++ b/apis/oss/v1alpha1/zz_annotation_types.go
@@ -26,7 +26,7 @@ type AnnotationInitParameters struct {
 	// (String) The ID of the dashboard on which to create the annotation.
 	// The ID of the dashboard on which to create the annotation.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	DashboardUID *string `json:"dashboardUid,omitempty" tf:"dashboard_uid,omitempty"`
@@ -116,7 +116,7 @@ type AnnotationParameters struct {
 	// (String) The ID of the dashboard on which to create the annotation.
 	// The ID of the dashboard on which to create the annotation.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_dashboard_types.go
+++ b/apis/oss/v1alpha1/zz_dashboard_types.go
@@ -22,7 +22,7 @@ type DashboardInitParameters struct {
 	// (String) The id or UID of the folder to save the dashboard in.
 	// The id or UID of the folder to save the dashboard in.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	Folder *string `json:"folder,omitempty" tf:"folder,omitempty"`
@@ -111,7 +111,7 @@ type DashboardParameters struct {
 	// (String) The id or UID of the folder to save the dashboard in.
 	// The id or UID of the folder to save the dashboard in.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_dashboardpermission_types.go
+++ b/apis/oss/v1alpha1/zz_dashboardpermission_types.go
@@ -26,7 +26,7 @@ type DashboardPermissionInitParameters struct {
 	// (String) UID of the dashboard to apply permissions to.
 	// UID of the dashboard to apply permissions to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	DashboardUID *string `json:"dashboardUid,omitempty" tf:"dashboard_uid,omitempty"`
@@ -82,7 +82,7 @@ type DashboardPermissionParameters struct {
 	// (String) UID of the dashboard to apply permissions to.
 	// UID of the dashboard to apply permissions to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_dashboardpublic_types.go
+++ b/apis/oss/v1alpha1/zz_dashboardpublic_types.go
@@ -34,7 +34,7 @@ type DashboardPublicInitParameters struct {
 	// (String) The unique identifier of the original dashboard.
 	// The unique identifier of the original dashboard.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	DashboardUID *string `json:"dashboardUid,omitempty" tf:"dashboard_uid,omitempty"`
@@ -132,7 +132,7 @@ type DashboardPublicParameters struct {
 	// (String) The unique identifier of the original dashboard.
 	// The unique identifier of the original dashboard.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Dashboard
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=DashboardRef
 	// +crossplane:generate:reference:selectorFieldName=DashboardSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_folder_types.go
+++ b/apis/oss/v1alpha1/zz_folder_types.go
@@ -41,7 +41,7 @@ type FolderInitParameters struct {
 	// (String) The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
 	// The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	ParentFolderUID *string `json:"parentFolderUid,omitempty" tf:"parent_folder_uid,omitempty"`
@@ -118,7 +118,7 @@ type FolderParameters struct {
 	// (String) The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
 	// The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_folderpermission_types.go
+++ b/apis/oss/v1alpha1/zz_folderpermission_types.go
@@ -26,7 +26,7 @@ type FolderPermissionInitParameters struct {
 	// (String) The UID of the folder.
 	// The UID of the folder.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	FolderUID *string `json:"folderUid,omitempty" tf:"folder_uid,omitempty"`
@@ -82,7 +82,7 @@ type FolderPermissionParameters struct {
 	// (String) The UID of the folder.
 	// The UID of the folder.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.Folder
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=FolderRef
 	// +crossplane:generate:reference:selectorFieldName=FolderSelector
 	// +kubebuilder:validation:Optional

--- a/apis/oss/v1alpha1/zz_generated.resolvers.go
+++ b/apis/oss/v1alpha1/zz_generated.resolvers.go
@@ -64,7 +64,7 @@ func (mg *Annotation) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DashboardRef,
 		Selector:     mg.Spec.ForProvider.DashboardSelector,
 		To: reference.To{
@@ -96,7 +96,7 @@ func (mg *Annotation) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DashboardRef,
 		Selector:     mg.Spec.InitProvider.DashboardSelector,
 		To: reference.To{
@@ -138,7 +138,7 @@ func (mg *Dashboard) ResolveReferences(ctx context.Context, c client.Reader) err
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Folder),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.FolderRef,
 		Selector:     mg.Spec.ForProvider.FolderSelector,
 		To: reference.To{
@@ -170,7 +170,7 @@ func (mg *Dashboard) ResolveReferences(ctx context.Context, c client.Reader) err
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Folder),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.FolderRef,
 		Selector:     mg.Spec.InitProvider.FolderSelector,
 		To: reference.To{
@@ -212,7 +212,7 @@ func (mg *DashboardPermission) ResolveReferences(ctx context.Context, c client.R
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DashboardRef,
 		Selector:     mg.Spec.ForProvider.DashboardSelector,
 		To: reference.To{
@@ -280,7 +280,7 @@ func (mg *DashboardPermission) ResolveReferences(ctx context.Context, c client.R
 	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DashboardRef,
 		Selector:     mg.Spec.InitProvider.DashboardSelector,
 		To: reference.To{
@@ -359,7 +359,7 @@ func (mg *DashboardPublic) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.DashboardRef,
 		Selector:     mg.Spec.ForProvider.DashboardSelector,
 		To: reference.To{
@@ -391,7 +391,7 @@ func (mg *DashboardPublic) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DashboardUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.DashboardRef,
 		Selector:     mg.Spec.InitProvider.DashboardSelector,
 		To: reference.To{
@@ -491,7 +491,7 @@ func (mg *Folder) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ParentFolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.FolderRef,
 		Selector:     mg.Spec.ForProvider.FolderSelector,
 		To: reference.To{
@@ -523,7 +523,7 @@ func (mg *Folder) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ParentFolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.FolderRef,
 		Selector:     mg.Spec.InitProvider.FolderSelector,
 		To: reference.To{
@@ -549,7 +549,7 @@ func (mg *FolderPermission) ResolveReferences(ctx context.Context, c client.Read
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.FolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.ForProvider.FolderRef,
 		Selector:     mg.Spec.ForProvider.FolderSelector,
 		To: reference.To{
@@ -617,7 +617,7 @@ func (mg *FolderPermission) ResolveReferences(ctx context.Context, c client.Read
 	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.FolderUID),
-		Extract:      grafana.UIDExtractor(),
+		Extract:      grafana.OptionalFieldExtractor("uid"),
 		Reference:    mg.Spec.InitProvider.FolderRef,
 		Selector:     mg.Spec.InitProvider.FolderSelector,
 		To: reference.To{
@@ -1085,7 +1085,7 @@ func (mg *Team) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Members),
-		Extract:       grafana.UserEmailExtractor(),
+		Extract:       grafana.FieldExtractor("email"),
 		References:    mg.Spec.ForProvider.MemberRefs,
 		Selector:      mg.Spec.ForProvider.MemberSelector,
 		To: reference.To{
@@ -1117,7 +1117,7 @@ func (mg *Team) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Members),
-		Extract:       grafana.UserEmailExtractor(),
+		Extract:       grafana.FieldExtractor("email"),
 		References:    mg.Spec.InitProvider.MemberRefs,
 		Selector:      mg.Spec.InitProvider.MemberSelector,
 		To: reference.To{

--- a/apis/oss/v1alpha1/zz_team_types.go
+++ b/apis/oss/v1alpha1/zz_team_types.go
@@ -101,7 +101,7 @@ type TeamInitParameters struct {
 	// A set of email addresses corresponding to users who should be given membership
 	// to the team. Note: users specified here must already exist in Grafana.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.User
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UserEmailExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("email")
 	// +crossplane:generate:reference:refFieldName=MemberRefs
 	// +crossplane:generate:reference:selectorFieldName=MemberSelector
 	// +listType=set
@@ -211,7 +211,7 @@ type TeamParameters struct {
 	// A set of email addresses corresponding to users who should be given membership
 	// to the team. Note: users specified here must already exist in Grafana.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.User
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UserEmailExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("email")
 	// +crossplane:generate:reference:refFieldName=MemberRefs
 	// +crossplane:generate:reference:selectorFieldName=MemberSelector
 	// +kubebuilder:validation:Optional

--- a/apis/slo/v1alpha1/zz_generated.resolvers.go
+++ b/apis/slo/v1alpha1/zz_generated.resolvers.go
@@ -24,7 +24,7 @@ func (mg *SLO) ResolveReferences(ctx context.Context, c client.Reader) error {
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.DestinationDatasource); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DestinationDatasource[i3].UID),
-			Extract:      grafana.UIDExtractor(),
+			Extract:      grafana.OptionalFieldExtractor("uid"),
 			Reference:    mg.Spec.ForProvider.DestinationDatasource[i3].Ref,
 			Selector:     mg.Spec.ForProvider.DestinationDatasource[i3].Selector,
 			To: reference.To{
@@ -42,7 +42,7 @@ func (mg *SLO) ResolveReferences(ctx context.Context, c client.Reader) error {
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.DestinationDatasource); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DestinationDatasource[i3].UID),
-			Extract:      grafana.UIDExtractor(),
+			Extract:      grafana.OptionalFieldExtractor("uid"),
 			Reference:    mg.Spec.InitProvider.DestinationDatasource[i3].Ref,
 			Selector:     mg.Spec.InitProvider.DestinationDatasource[i3].Selector,
 			To: reference.To{

--- a/apis/slo/v1alpha1/zz_slo_types.go
+++ b/apis/slo/v1alpha1/zz_slo_types.go
@@ -145,7 +145,7 @@ type DestinationDatasourceInitParameters struct {
 	// (String) UID for the Mimir Datasource
 	// UID for the Mimir Datasource
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=Ref
 	// +crossplane:generate:reference:selectorFieldName=Selector
 	UID *string `json:"uid,omitempty" tf:"uid,omitempty"`
@@ -171,7 +171,7 @@ type DestinationDatasourceParameters struct {
 	// (String) UID for the Mimir Datasource
 	// UID for the Mimir Datasource
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1.DataSource
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.UIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.OptionalFieldExtractor("uid")
 	// +crossplane:generate:reference:refFieldName=Ref
 	// +crossplane:generate:reference:selectorFieldName=Selector
 	// +kubebuilder:validation:Optional

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -11,11 +11,6 @@ import (
 	ujconfig "github.com/crossplane/upjet/pkg/config"
 )
 
-const (
-	// SelfPackagePath is the golang path for this package.
-	SelfPackagePath = "github.com/grafana/crossplane-provider-grafana/config/grafana"
-)
-
 // ConfigureOrgIDRefs adds an organization reference to the org_id field for all resources that have the field.
 func ConfigureOrgIDRefs(p *ujconfig.Provider) {
 	for name, resource := range p.Resources {
@@ -45,7 +40,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_dashboard",
 			RefFieldName:      "DashboardRef",
 			SelectorFieldName: "DashboardSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_notification_policy", func(r *ujconfig.Resource) {
@@ -53,7 +48,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_contact_point",
 			RefFieldName:      "ContactPointRef",
 			SelectorFieldName: "ContactPointSelector",
-			Extractor:         SelfPackagePath + ".NameExtractor()",
+			Extractor:         fieldExtractor("name"),
 		}
 		r.References["contact_point"] = contactPointRef
 		r.References["policy.contact_point"] = contactPointRef
@@ -65,7 +60,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_mute_timing",
 			RefFieldName:      "MuteTimingRef",
 			SelectorFieldName: "MuteTimingSelector",
-			Extractor:         SelfPackagePath + ".NameExtractor()",
+			Extractor:         fieldExtractor("name"),
 		}
 		r.References["policy.mute_timings"] = muteTimingRef
 		r.References["policy.policy.mute_timings"] = muteTimingRef
@@ -103,7 +98,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_access_policy",
 			RefFieldName:      "AccessPolicyRef",
 			SelectorFieldName: "AccessPolicySelector",
-			Extractor:         SelfPackagePath + ".PolicyIDExtractor()",
+			Extractor:         computedFieldExtractor("policyId"),
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
@@ -124,7 +119,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack",
 			RefFieldName:      "CloudStackRef",
 			SelectorFieldName: "CloudStackSelector",
-			Extractor:         SelfPackagePath + ".CloudStackSlugExtractor()",
+			Extractor:         fieldExtractor("slug"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_cloud_stack", func(r *ujconfig.Resource) {
@@ -135,7 +130,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack",
 			RefFieldName:      "CloudStackRef",
 			SelectorFieldName: "CloudStackSelector",
-			Extractor:         SelfPackagePath + ".CloudStackSlugExtractor()",
+			Extractor:         fieldExtractor("slug"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_cloud_stack_service_account_token", func(r *ujconfig.Resource) {
@@ -143,7 +138,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack",
 			RefFieldName:      "CloudStackRef",
 			SelectorFieldName: "CloudStackSelector",
-			Extractor:         SelfPackagePath + ".CloudStackSlugExtractor()",
+			Extractor:         fieldExtractor("slug"),
 		}
 		r.References["service_account_id"] = ujconfig.Reference{
 			TerraformName:     "grafana_cloud_stack_service_account",
@@ -215,7 +210,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_folder",
 			RefFieldName:      "FolderRef",
 			SelectorFieldName: "FolderSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_dashboard_public", func(r *ujconfig.Resource) {
@@ -223,7 +218,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_dashboard",
 			RefFieldName:      "DashboardRef",
 			SelectorFieldName: "DashboardSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_dashboard_permission", func(r *ujconfig.Resource) {
@@ -232,7 +227,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_dashboard",
 			RefFieldName:      "DashboardRef",
 			SelectorFieldName: "DashboardSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 		r.References["permissions.team_id"] = ujconfig.Reference{
 			TerraformName:     "grafana_team",
@@ -267,7 +262,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_folder",
 			RefFieldName:      "FolderRef",
 			SelectorFieldName: "FolderSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_folder_permission", func(r *ujconfig.Resource) {
@@ -275,7 +270,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_folder",
 			RefFieldName:      "FolderRef",
 			SelectorFieldName: "FolderSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 		r.References["permissions.team_id"] = ujconfig.Reference{
 			TerraformName:     "grafana_team",
@@ -300,7 +295,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_contact_point",
 			RefFieldName:      "ContactPointRef",
 			SelectorFieldName: "ContactPointSelector",
-			Extractor:         SelfPackagePath + ".NameExtractor()",
+			Extractor:         fieldExtractor("name"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_report", func(r *ujconfig.Resource) {
@@ -309,7 +304,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_dashboard",
 			RefFieldName:      "DashboardRef",
 			SelectorFieldName: "DashboardSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_role_assignment", func(r *ujconfig.Resource) {
@@ -317,7 +312,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_role",
 			RefFieldName:      "RoleRef",
 			SelectorFieldName: "RoleSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 		r.References["service_accounts"] = ujconfig.Reference{
 			TerraformName:     "grafana_service_account",
@@ -340,7 +335,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_folder",
 			RefFieldName:      "FolderRef",
 			SelectorFieldName: "FolderSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_team", func(r *ujconfig.Resource) {
@@ -348,7 +343,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_user",
 			RefFieldName:      "MemberRefs",
 			SelectorFieldName: "MemberSelector",
-			Extractor:         SelfPackagePath + ".UserEmailExtractor()",
+			Extractor:         fieldExtractor("email"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_team_external_group", func(r *ujconfig.Resource) {
@@ -390,7 +385,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_data_source",
 			RefFieldName:      "DataSourceRef",
 			SelectorFieldName: "DataSourceSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 
@@ -399,7 +394,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_data_source",
 			RefFieldName:      "DataSourceRef",
 			SelectorFieldName: "DataSourceSelector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 
@@ -408,7 +403,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_data_source",
 			RefFieldName:      "Ref",
 			SelectorFieldName: "Selector",
-			Extractor:         SelfPackagePath + ".UIDExtractor()",
+			Extractor:         optionalFieldExtractor("uid"),
 		}
 	})
 }

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -103,6 +103,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_access_policy",
 			RefFieldName:      "AccessPolicyRef",
 			SelectorFieldName: "AccessPolicySelector",
+			Extractor:         SelfPackagePath + ".PolicyIDExtractor()",
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}

--- a/config/grafana/extractors.go
+++ b/config/grafana/extractors.go
@@ -70,3 +70,18 @@ func UserEmailExtractor() reference.ExtractValueFn {
 		return r
 	}
 }
+
+// nolint: golint
+func PolicyIDExtractor() reference.ExtractValueFn {
+	return func(mg xpresource.Managed) string {
+		paved, err := fieldpath.PaveObject(mg)
+		if err != nil {
+			return ""
+		}
+		r, err := paved.GetString("status.atProvider.policyId")
+		if err != nil {
+			return ""
+		}
+		return r
+	}
+}

--- a/config/grafana/extractors.go
+++ b/config/grafana/extractors.go
@@ -51,6 +51,7 @@ func FieldExtractor(field string) reference.ExtractValueFn {
 	}
 }
 
+// nolint: unparam
 func optionalFieldExtractor(field string) string {
 	return fmt.Sprintf("%s.OptionalFieldExtractor(%q)", SelfPackagePath, field)
 }


### PR DESCRIPTION
We should use the `.policy_id` attribute, not the `.id` for reference in an access policy token. Also, refactor references