### PR TITLE
Recreate token/key resources if the secret is missing

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -160,9 +160,12 @@ func Configure(p *ujconfig.Provider) {
 
 			// The key may not be returned in the state, so we need to recreate the key if it is missing
 			if _, ok := state.Attributes["key"]; !ok {
-				return &terraform.InstanceDiff{Destroy: true}, nil
+				if diff == nil {
+					diff = &terraform.InstanceDiff{}
+				}
+				diff.DestroyTainted = true
+				return diff, nil
 			}
-
 			return diff, nil
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -363,7 +363,7 @@ func Configure(p *ujconfig.Provider) {
 			RefFieldName:      "CloudStackRef",
 			SelectorFieldName: "CloudStackSelector",
 		}
-
+		r.TerraformCustomDiff = recreateIfAttributeMissing("sm_access_token")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -154,10 +154,15 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "ServiceAccountSelector",
 		}
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			if state == nil {
+				return diff, nil
+			}
+
 			// The key may not be returned in the state, so we need to recreate the key if it is missing
 			if _, ok := state.Attributes["key"]; !ok {
-				state.Tainted = true
+				return &terraform.InstanceDiff{Destroy: true}, nil
 			}
+
 			return diff, nil
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -156,7 +156,7 @@ func Configure(p *ujconfig.Provider) {
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			// The key may not be returned in the state, so we need to recreate the key if it is missing
 			if _, ok := state.Attributes["key"]; !ok {
-				diff.DestroyTainted = true
+				state.Tainted = true
 			}
 			return diff, nil
 		}

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -164,8 +164,8 @@ func Configure(p *ujconfig.Provider) {
 					diff = &terraform.InstanceDiff{}
 				}
 				diff.DestroyTainted = true
-				return diff, nil
 			}
+
 			return diff, nil
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	ujconfig "github.com/crossplane/upjet/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // ConfigureOrgIDRefs adds an organization reference to the org_id field for all resources that have the field.
@@ -100,6 +101,13 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "AccessPolicySelector",
 			Extractor:         computedFieldExtractor("policyId"),
 		}
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			// The token may not be returned in the state, so we need to recreate the token if it is missing
+			if _, ok := state.Attributes["token"]; !ok {
+				diff.DestroyTainted = true
+			}
+			return diff, nil
+		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			cloudConfig := map[string]string{}
@@ -144,6 +152,13 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack_service_account",
 			RefFieldName:      "ServiceAccountRef",
 			SelectorFieldName: "ServiceAccountSelector",
+		}
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			// The key may not be returned in the state, so we need to recreate the key if it is missing
+			if _, ok := state.Attributes["key"]; !ok {
+				diff.DestroyTainted = true
+			}
+			return diff, nil
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}


### PR DESCRIPTION
If Crossplane loses track of an exported connection secret, it goes into an "invalid" state where the resource is tracked but it has no actual secret (because it isn't returned by the API)

With this PR, this state will be automatically resolved because the resource will be tainted and recreated if the "token" or "key" attribute of those resources is missing