### PR TITLE
Add ContactPointRef and ContactPointSelector fields to rulegroups.alerting.grafana.crossplane.io

### DIFF
--- a/apis/alerting/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/alerting/v1alpha1/zz_generated.deepcopy.go
@@ -2890,6 +2890,16 @@ func (in *NotificationSettingsInitParameters) DeepCopyInto(out *NotificationSett
 		*out = new(string)
 		**out = **in
 	}
+	if in.ContactPointRef != nil {
+		in, out := &in.ContactPointRef, &out.ContactPointRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ContactPointSelector != nil {
+		in, out := &in.ContactPointSelector, &out.ContactPointSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.GroupBy != nil {
 		in, out := &in.GroupBy, &out.GroupBy
 		*out = make([]*string, len(*in))
@@ -3003,6 +3013,16 @@ func (in *NotificationSettingsParameters) DeepCopyInto(out *NotificationSettings
 		in, out := &in.ContactPoint, &out.ContactPoint
 		*out = new(string)
 		**out = **in
+	}
+	if in.ContactPointRef != nil {
+		in, out := &in.ContactPointRef, &out.ContactPointRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ContactPointSelector != nil {
+		in, out := &in.ContactPointSelector, &out.ContactPointSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.GroupBy != nil {
 		in, out := &in.GroupBy, &out.GroupBy

--- a/apis/alerting/v1alpha1/zz_generated.resolvers.go
+++ b/apis/alerting/v1alpha1/zz_generated.resolvers.go
@@ -591,6 +591,26 @@ func (mg *RuleGroup) ResolveReferences(ctx context.Context, c client.Reader) err
 	mg.Spec.ForProvider.OrgID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.OrganizationRef = rsp.ResolvedReference
 
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Rule); i3++ {
+		for i4 := 0; i4 < len(mg.Spec.ForProvider.Rule[i3].NotificationSettings); i4++ {
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPoint),
+				Extract:      grafana.FieldExtractor("name"),
+				Reference:    mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPointRef,
+				Selector:     mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPointSelector,
+				To: reference.To{
+					List:    &ContactPointList{},
+					Managed: &ContactPoint{},
+				},
+			})
+			if err != nil {
+				return errors.Wrap(err, "mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPoint")
+			}
+			mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPoint = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Rule[i3].NotificationSettings[i4].ContactPointRef = rsp.ResolvedReference
+
+		}
+	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.FolderUID),
 		Extract:      grafana.OptionalFieldExtractor("uid"),
@@ -622,6 +642,27 @@ func (mg *RuleGroup) ResolveReferences(ctx context.Context, c client.Reader) err
 	}
 	mg.Spec.InitProvider.OrgID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.InitProvider.OrganizationRef = rsp.ResolvedReference
+
+	for i3 := 0; i3 < len(mg.Spec.InitProvider.Rule); i3++ {
+		for i4 := 0; i4 < len(mg.Spec.InitProvider.Rule[i3].NotificationSettings); i4++ {
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPoint),
+				Extract:      grafana.FieldExtractor("name"),
+				Reference:    mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPointRef,
+				Selector:     mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPointSelector,
+				To: reference.To{
+					List:    &ContactPointList{},
+					Managed: &ContactPoint{},
+				},
+			})
+			if err != nil {
+				return errors.Wrap(err, "mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPoint")
+			}
+			mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPoint = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.InitProvider.Rule[i3].NotificationSettings[i4].ContactPointRef = rsp.ResolvedReference
+
+		}
+	}
 
 	return nil
 }

--- a/apis/alerting/v1alpha1/zz_rulegroup_types.go
+++ b/apis/alerting/v1alpha1/zz_rulegroup_types.go
@@ -91,7 +91,19 @@ type NotificationSettingsInitParameters struct {
 
 	// (String) The contact point to route notifications that match this rule to.
 	// The contact point to route notifications that match this rule to.
+	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
+	// +crossplane:generate:reference:refFieldName=ContactPointRef
+	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
+
+	// Reference to a ContactPoint in alerting to populate contactPoint.
+	// +kubebuilder:validation:Optional
+	ContactPointRef *v1.Reference `json:"contactPointRef,omitempty" tf:"-"`
+
+	// Selector for a ContactPoint in alerting to populate contactPoint.
+	// +kubebuilder:validation:Optional
+	ContactPointSelector *v1.Selector `json:"contactPointSelector,omitempty" tf:"-"`
 
 	// (List of String) A list of alert labels to group alerts into notifications by. Use the special label ... to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
 	// A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
@@ -145,8 +157,20 @@ type NotificationSettingsParameters struct {
 
 	// (String) The contact point to route notifications that match this rule to.
 	// The contact point to route notifications that match this rule to.
+	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1.ContactPoint
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.FieldExtractor("name")
+	// +crossplane:generate:reference:refFieldName=ContactPointRef
+	// +crossplane:generate:reference:selectorFieldName=ContactPointSelector
 	// +kubebuilder:validation:Optional
-	ContactPoint *string `json:"contactPoint" tf:"contact_point,omitempty"`
+	ContactPoint *string `json:"contactPoint,omitempty" tf:"contact_point,omitempty"`
+
+	// Reference to a ContactPoint in alerting to populate contactPoint.
+	// +kubebuilder:validation:Optional
+	ContactPointRef *v1.Reference `json:"contactPointRef,omitempty" tf:"-"`
+
+	// Selector for a ContactPoint in alerting to populate contactPoint.
+	// +kubebuilder:validation:Optional
+	ContactPointSelector *v1.Selector `json:"contactPointSelector,omitempty" tf:"-"`
 
 	// (List of String) A list of alert labels to group alerts into notifications by. Use the special label ... to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
 	// A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -442,6 +442,12 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "FolderSelector",
 			Extractor:         optionalFieldExtractor("uid"),
 		}
+		r.References["rule.notification_settings.contact_point"] = ujconfig.Reference{
+			TerraformName:     "grafana_contact_point",
+			RefFieldName:      "ContactPointRef",
+			SelectorFieldName: "ContactPointSelector",
+			Extractor:         fieldExtractor("name"),
+		}
 	})
 	p.AddResourceConfigurator("grafana_team", func(r *ujconfig.Resource) {
 		r.References["members"] = ujconfig.Reference{

--- a/package/crds/alerting.grafana.crossplane.io_rulegroups.yaml
+++ b/package/crds/alerting.grafana.crossplane.io_rulegroups.yaml
@@ -355,6 +355,82 @@ spec:
                                   (String) The contact point to route notifications that match this rule to.
                                   The contact point to route notifications that match this rule to.
                                 type: string
+                              contactPointRef:
+                                description: Reference to a ContactPoint in alerting
+                                  to populate contactPoint.
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                  policy:
+                                    description: Policies for referencing.
+                                    properties:
+                                      resolution:
+                                        default: Required
+                                        description: |-
+                                          Resolution specifies whether resolution of this reference is required.
+                                          The default is 'Required', which means the reconcile will fail if the
+                                          reference cannot be resolved. 'Optional' means this reference will be
+                                          a no-op if it cannot be resolved.
+                                        enum:
+                                        - Required
+                                        - Optional
+                                        type: string
+                                      resolve:
+                                        description: |-
+                                          Resolve specifies when this reference should be resolved. The default
+                                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                                          the corresponding field is not present. Use 'Always' to resolve the
+                                          reference on every reconcile.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        type: string
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              contactPointSelector:
+                                description: Selector for a ContactPoint in alerting
+                                  to populate contactPoint.
+                                properties:
+                                  matchControllerRef:
+                                    description: |-
+                                      MatchControllerRef ensures an object with the same controller reference
+                                      as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                  policy:
+                                    description: Policies for selection.
+                                    properties:
+                                      resolution:
+                                        default: Required
+                                        description: |-
+                                          Resolution specifies whether resolution of this reference is required.
+                                          The default is 'Required', which means the reconcile will fail if the
+                                          reference cannot be resolved. 'Optional' means this reference will be
+                                          a no-op if it cannot be resolved.
+                                        enum:
+                                        - Required
+                                        - Optional
+                                        type: string
+                                      resolve:
+                                        description: |-
+                                          Resolve specifies when this reference should be resolved. The default
+                                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                                          the corresponding field is not present. Use 'Always' to resolve the
+                                          reference on every reconcile.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        type: string
+                                    type: object
+                                type: object
                               groupBy:
                                 description: |-
                                   (List of String) A list of alert labels to group alerts into notifications by. Use the special label ... to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
@@ -682,6 +758,82 @@ spec:
                                   (String) The contact point to route notifications that match this rule to.
                                   The contact point to route notifications that match this rule to.
                                 type: string
+                              contactPointRef:
+                                description: Reference to a ContactPoint in alerting
+                                  to populate contactPoint.
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                  policy:
+                                    description: Policies for referencing.
+                                    properties:
+                                      resolution:
+                                        default: Required
+                                        description: |-
+                                          Resolution specifies whether resolution of this reference is required.
+                                          The default is 'Required', which means the reconcile will fail if the
+                                          reference cannot be resolved. 'Optional' means this reference will be
+                                          a no-op if it cannot be resolved.
+                                        enum:
+                                        - Required
+                                        - Optional
+                                        type: string
+                                      resolve:
+                                        description: |-
+                                          Resolve specifies when this reference should be resolved. The default
+                                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                                          the corresponding field is not present. Use 'Always' to resolve the
+                                          reference on every reconcile.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        type: string
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              contactPointSelector:
+                                description: Selector for a ContactPoint in alerting
+                                  to populate contactPoint.
+                                properties:
+                                  matchControllerRef:
+                                    description: |-
+                                      MatchControllerRef ensures an object with the same controller reference
+                                      as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                  policy:
+                                    description: Policies for selection.
+                                    properties:
+                                      resolution:
+                                        default: Required
+                                        description: |-
+                                          Resolution specifies whether resolution of this reference is required.
+                                          The default is 'Required', which means the reconcile will fail if the
+                                          reference cannot be resolved. 'Optional' means this reference will be
+                                          a no-op if it cannot be resolved.
+                                        enum:
+                                        - Required
+                                        - Optional
+                                        type: string
+                                      resolve:
+                                        description: |-
+                                          Resolve specifies when this reference should be resolved. The default
+                                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                                          the corresponding field is not present. Use 'Always' to resolve the
+                                          reference on every reconcile.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        type: string
+                                    type: object
+                                type: object
                               groupBy:
                                 description: |-
                                   (List of String) A list of alert labels to group alerts into notifications by. Use the special label ... to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.


### PR DESCRIPTION
### Description of your changes

This PR adds reference and selector support to the `alerting.grafana.crossplane.io` `RuleGroup` resource.
With that, one can use a contact point selector like follows:
```yaml
apiVersion: alerting.grafana.crossplane.io/v1alpha1
kind: RuleGroup
metadata:
  name: "example"
spec:
  forProvider:
    name: "example"
    ...
    rule:
      - notificationSettings:
        - contactPointSelector:
            matchLabels:
              label: value

```

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally with kind cluster and k8s objects against grafana cloud API.


