### PR TITLE
fix(cloud_access_policy): extract 'id' field explicitly for reference

### DIFF
--- a/apis/cloud/v1alpha1/zz_accesspolicy_types.go
+++ b/apis/cloud/v1alpha1/zz_accesspolicy_types.go
@@ -129,6 +129,7 @@ type RealmInitParameters struct {
 	// (String) The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("id")
 	// +crossplane:generate:reference:refFieldName=StackRef
 	// +crossplane:generate:reference:selectorFieldName=StackSelector
 	Identifier *string `json:"identifier,omitempty" tf:"identifier,omitempty"`
@@ -168,6 +169,7 @@ type RealmParameters struct {
 	// (String) The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// The identifier of the org or stack. For orgs, this is the slug, for stacks, this is the stack ID.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("id")
 	// +crossplane:generate:reference:refFieldName=StackRef
 	// +crossplane:generate:reference:selectorFieldName=StackSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloud/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cloud/v1alpha1/zz_generated.resolvers.go
@@ -23,7 +23,7 @@ func (mg *AccessPolicy) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Realm); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Realm[i3].Identifier),
-			Extract:      reference.ExternalName(),
+			Extract:      grafana.ComputedFieldExtractor("id"),
 			Reference:    mg.Spec.ForProvider.Realm[i3].StackRef,
 			Selector:     mg.Spec.ForProvider.Realm[i3].StackSelector,
 			To: reference.To{
@@ -41,7 +41,7 @@ func (mg *AccessPolicy) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Realm); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Realm[i3].Identifier),
-			Extract:      reference.ExternalName(),
+			Extract:      grafana.ComputedFieldExtractor("id"),
 			Reference:    mg.Spec.InitProvider.Realm[i3].StackRef,
 			Selector:     mg.Spec.InitProvider.Realm[i3].StackSelector,
 			To: reference.To{

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -171,6 +171,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack",
 			RefFieldName:      "StackRef",
 			SelectorFieldName: "StackSelector",
+			Extractor:         computedFieldExtractor("id"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_cloud_access_policy_token", func(r *ujconfig.Resource) {


### PR DESCRIPTION
We are observing that an AccessPolicy using StackRefSelector has `realm.identifier` match the `slug` of a stack while the `realm.identifier` always expects the `id` to be extracted.

It's not clear why this happens to me as by default the Extractor field should get populated with the 'external-name':

https://github.com/crossplane/upjet/blob/a18bd41b7ac62be1a6058512a13f8a001c8087d9/pkg/config/resource.go#L191-L194

And in this particular case, the external-name on the stack does seem to match the `id` BUT in the composition/claim we do set the value of external-name to match the `slug` as that is what Crossplane initially needs to find the matching stack, this depends on the [import](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack#import) using `stackSlugOrID`. This means it works for the stack resource. Now it is crossplane constantly racing to update the external-name field, when it comes from the claim it'll be the `slug,` if it comes from the Grafana API it will be the `id`. Depending on order of reconcilation, the `realm.identifier` flips values too, explaining why it works 'sometimes'.

Big thanks to @julienduchesne for finding this last bit.

The change in this PR makes the extraction of `id` explicit now.
