### PR TITLE
fix(grafana_synthetic_monitoring_installation): extract 'id' field explicitly for reference

### DIFF
--- a/apis/sm/v1alpha1/zz_generated.resolvers.go
+++ b/apis/sm/v1alpha1/zz_generated.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	v1alpha1 "github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1"
+	grafana "github.com/grafana/crossplane-provider-grafana/config/grafana"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,7 +23,7 @@ func (mg *Installation) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.StackID),
-		Extract:      reference.ExternalName(),
+		Extract:      grafana.ComputedFieldExtractor("id"),
 		Reference:    mg.Spec.ForProvider.CloudStackRef,
 		Selector:     mg.Spec.ForProvider.CloudStackSelector,
 		To: reference.To{
@@ -38,7 +39,7 @@ func (mg *Installation) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.StackID),
-		Extract:      reference.ExternalName(),
+		Extract:      grafana.ComputedFieldExtractor("id"),
 		Reference:    mg.Spec.InitProvider.CloudStackRef,
 		Selector:     mg.Spec.InitProvider.CloudStackSelector,
 		To: reference.To{

--- a/apis/sm/v1alpha1/zz_installation_types.go
+++ b/apis/sm/v1alpha1/zz_installation_types.go
@@ -30,6 +30,7 @@ type InstallationInitParameters struct {
 	// (String) The ID or slug of the stack to install SM on.
 	// The ID or slug of the stack to install SM on.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("id")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	StackID *string `json:"stackId,omitempty" tf:"stack_id,omitempty"`
@@ -75,6 +76,7 @@ type InstallationParameters struct {
 	// (String) The ID or slug of the stack to install SM on.
 	// The ID or slug of the stack to install SM on.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1.Stack
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/config/grafana.ComputedFieldExtractor("id")
 	// +crossplane:generate:reference:refFieldName=CloudStackRef
 	// +crossplane:generate:reference:selectorFieldName=CloudStackSelector
 	// +kubebuilder:validation:Optional

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -450,6 +450,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_cloud_stack",
 			RefFieldName:      "CloudStackRef",
 			SelectorFieldName: "CloudStackSelector",
+			Extractor:         computedFieldExtractor("id"),
 		}
 		r.TerraformCustomDiff = recreateIfAttributeMissing("sm_access_token")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {


### PR DESCRIPTION
CloudStackRef can either be the slug or the id, the `grafana_cloud_access_policy_token` only takes an `id`, this PR will make sure that always happens.

