### PR TITLE
fix(GITHUB_ISSUES): Add an example title

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: "REPLACE_ME"
 type: "bug"
 projects: ["grafana/513"] # Platform Monitoring
 body:

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: ""
+title: "REPLACE_ME"
 type: "bug"
 projects: ["grafana/513"] # Platform Monitoring
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for this provider
-title: ""
+title: "REPLACE_ME"
 type: "enhancement"
 projects: ["grafana/513"] # Platform Monitoring
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest an idea for this provider
-title: "REPLACE_ME"
 type: "enhancement"
 projects: ["grafana/513"] # Platform Monitoring
 body:


### PR DESCRIPTION
GitHub was complaining that the `title: ""` was an empty string. Here are the
[docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string) about the error.

I didn't try it, but another possible solution would be to remove the title all together.

![image](https://github.com/user-attachments/assets/4154d1c1-a1d3-4f65-8e1c-d2e9a916af3f)
