### PR TITLE
ci(dependabot): ignore upjet related dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # Needs to be updated together with github.com/crossplane/upjet
+      - dependency-name: "sigs.k8s.io/controller-tools"
+      # Needs to be updated together with github.com/crossplane/upjet
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Needs to be updated together with github.com/crossplane/upjet
+      - dependency-name: "github.com/crossplane/crossplane-runtime"


### PR DESCRIPTION
This tells dependabot to ignore some dependencies that need to align with upjet, they'll get updated once upjet moves forward.
