### PR TITLE
AccessPolicyToken: Add basic auth credentials to ConnectionSecret for use with DataSource

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -186,14 +186,23 @@ func Configure(p *ujconfig.Provider) {
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			cloudConfig := map[string]string{}
+			basicAuthConfig := map[string]string{}
 			if a, ok := attr["token"].(string); ok {
 				cloudConfig["cloud_access_policy_token"] = a
+				basicAuthConfig["basicAuthPassword"] = a
 			}
-			marshalled, err := json.Marshal(cloudConfig)
+
+			marshalledBasicAuthConfig, err := json.Marshal(basicAuthConfig)
 			if err != nil {
 				return nil, err
 			}
-			conn["cloudCredentials"] = marshalled
+			conn["basicAuthCredentials"] = marshalledBasicAuthConfig
+
+			marshalledCloudConfig, err := json.Marshal(cloudConfig)
+			if err != nil {
+				return nil, err
+			}
+			conn["cloudCredentials"] = marshalledCloudConfig
 			return conn, nil
 		}
 	})

--- a/examples/datasource-with-access-policy-basic-auth.yaml
+++ b/examples/datasource-with-access-policy-basic-auth.yaml
@@ -1,0 +1,65 @@
+# Example that creates a DataSource that uses BasicAuth to connect to a Prometheus endpoint
+# Note: There exists a race condition between access policy token and datasource as datasource currently
+# does not block creation if secureJsonDataEncodedSecretRef points to a non-existing secret.
+apiVersion: cloud.grafana.crossplane.io/v1alpha1
+kind: AccessPolicy
+metadata:
+  name: example-datasource-with-basic-auth
+  labels:
+    example.com/name: example-datasource-with-basic-auth
+spec:
+  forProvider:
+    name: example-datasource-with-basic-auth
+    realm:
+    - labelPolicy:
+      - selector: '{foo="bar"}'
+      type: stack
+      identifier: "STACKID" # changeme
+    region: REGION # changeme
+    scopes:
+    - metrics:read
+    - logs:read
+  providerConfigRef:
+    name: grafana-cloud-provider
+---
+apiVersion: cloud.grafana.crossplane.io/v1alpha1
+kind: AccessPolicyToken
+metadata:
+  name: example-datasource-with-basic-auth
+spec:
+  forProvider:
+    accessPolicySelector:
+      matchLabels:
+        example.com/name: example-datasource-with-basic-auth
+    name: example-datasource-with-basic-auth
+    region: REGION  # changeme
+  writeConnectionSecretToRef:
+    name: example-datasource-with-basic-auth
+    namespace: crossplane
+  providerConfigRef:
+    name: grafana-cloud-provider
+---
+apiVersion: oss.grafana.crossplane.io/v1alpha1
+kind: DataSource
+metadata:
+  labels:
+    example.com/name: example-datasource-with-basic-auth
+  name: example-datasource-with-basic-auth
+spec:
+  forProvider:
+    name: example-datasource-with-basic-auth
+    type: prometheus
+    url: URL  # changeme
+    basicAuthEnabled: true
+    basicAuthUsername: "USERID"  # changeme
+    jsonDataEncoded: |
+      {
+        "httpMethod": "POST",
+        "tokenName": "example-datasource-with-basic-auth"
+      }
+    secureJsonDataEncodedSecretRef:
+      key: basicAuthCredentials
+      name: example-datasource-with-basic-auth
+      namespace: crossplane
+  providerConfigRef:
+    name: grafana-cloud-instance-provider


### PR DESCRIPTION
### Description of your changes

This PR changes the connection secret created by `accesspolicytokens.cloud.grafana.crossplane.io` so that it contains an additional key that can be used by datasources (`datasources.oss.grafana.crossplane.io`) that make use of basic authentication.

In detail, a new key `basicAuthCredentials` is added to the connection secret. It contains a stringified JSON-object with the following content:

```
{"basicAuthPassword": "<TOKEN>"}
```

We also provided an example to see how it can be used.

Fixes #238 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* Run the provider locally and applied the example (with replaced "changeme" fields).
* Checked that the datasource was properly created in grafana cloud (basic auth password configured and connection working)


