### PR TITLE
chore(dependabot): ignore k8s.io/client-go and k8s.io/apimachinery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     ignore:
       # Needs to be updated together with github.com/crossplane/upjet
       - dependency-name: "sigs.k8s.io/controller-tools"
-      # Needs to be updated together with github.com/crossplane/upjet
       - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Needs to be updated together with github.com/crossplane/upjet
       - dependency-name: "github.com/crossplane/crossplane-runtime"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/apimachinery"


### PR DESCRIPTION
These needs to be updated together with github.com/crossplane/upjet as well.

