### PR TITLE
fix(clients): support connecting to several APIs

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -20,6 +20,8 @@ type ProviderConfigSpec struct {
 	OnCallURL string `json:"oncallUrl,omitempty"`
 	// Override the Synthetic Monitoring API URL from the credentials reference attribute.
 	SMURL string `json:"smUrl,omitempty"`
+	// Override the Connections API from the credentials reference attribute.
+	ConnectionsAPIURL string `json:"connectionsApiUrl,omitempty"`
 
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -16,12 +16,16 @@ type ProviderConfigSpec struct {
 	URL string `json:"url,omitempty"`
 	// Override the Grafana Cloud API URL from the credentials reference attribute.
 	CloudAPIURL string `json:"cloudApiUrl,omitempty"`
+	// Override the Cloud Provider API from the credentials reference attribute.
+	CloudProviderURL string `json:"cloudProviderUrl,omitempty"`
+	// Override the Connections API from the credentials reference attribute.
+	ConnectionsAPIURL string `json:"connectionsApiUrl,omitempty"`
+	// Override the FleetManagement API from the credentials reference attribute.
+	FleetManagementURL string `json:"fleetManagementUrl,omitempty"`
 	// Override the OnCall API URL from the credentials reference attribute.
 	OnCallURL string `json:"oncallUrl,omitempty"`
 	// Override the Synthetic Monitoring API URL from the credentials reference attribute.
 	SMURL string `json:"smUrl,omitempty"`
-	// Override the Connections API from the credentials reference attribute.
-	ConnectionsAPIURL string `json:"connectionsApiUrl,omitempty"`
 
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -73,6 +73,8 @@ func TerraformSetupBuilder() terraform.SetupFn {
 			"sm_access_token",
 			"sm_url",
 			"org_id",
+			"connections_api_url",
+			"connections_api_access_token",
 		} {
 			if v, ok := creds[k]; ok {
 				ps.Configuration[k] = v
@@ -90,6 +92,9 @@ func TerraformSetupBuilder() terraform.SetupFn {
 		}
 		if pc.Spec.SMURL != "" {
 			ps.Configuration["sm_url"] = pc.Spec.SMURL
+		}
+		if pc.Spec.ConnectionsAPIURL != "" {
+			ps.Configuration["sm_url"] = pc.Spec.ConnectionsAPIURL
 		}
 
 		if err := configureNoForkGrafanaClient(ctx, &ps); err != nil {

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -63,18 +63,31 @@ func TerraformSetupBuilder() terraform.SetupFn {
 		// https://registry.terraform.io/providers/grafana/grafana/latest/docs
 		ps.Configuration = map[string]any{}
 		for _, k := range []string{
-			"url",
 			"auth",
+			"url",
+
 			"cloud_access_policy_token",
-			"cloud_api_key",
 			"cloud_api_url",
+
+			"cloud_provider_access_token",
+			"cloud_provider_url",
+
+			"connections_api_access_token",
+			"connections_api_url",
+
+			"fleet_management_auth",
+			"fleet_management_url",
+
+			"frontend_o11y_api_access_token",
+
 			"oncall_access_token",
 			"oncall_url",
+
 			"sm_access_token",
 			"sm_url",
-			"org_id",
-			"connections_api_url",
-			"connections_api_access_token",
+
+			"cloud_api_key", // don't see it in the TF config
+			"org_id",        // don't see it in the TF config
 		} {
 			if v, ok := creds[k]; ok {
 				ps.Configuration[k] = v
@@ -87,14 +100,20 @@ func TerraformSetupBuilder() terraform.SetupFn {
 		if pc.Spec.CloudAPIURL != "" {
 			ps.Configuration["cloud_api_url"] = pc.Spec.CloudAPIURL
 		}
+		if pc.Spec.CloudProviderURL != "" {
+			ps.Configuration["cloud_provider_url"] = pc.Spec.CloudProviderURL
+		}
+		if pc.Spec.ConnectionsAPIURL != "" {
+			ps.Configuration["connections_api_url"] = pc.Spec.ConnectionsAPIURL
+		}
+		if pc.Spec.FleetManagementURL != "" {
+			ps.Configuration["fleet_management_url"] = pc.Spec.FleetManagementURL
+		}
 		if pc.Spec.OnCallURL != "" {
 			ps.Configuration["oncall_url"] = pc.Spec.OnCallURL
 		}
 		if pc.Spec.SMURL != "" {
 			ps.Configuration["sm_url"] = pc.Spec.SMURL
-		}
-		if pc.Spec.ConnectionsAPIURL != "" {
-			ps.Configuration["sm_url"] = pc.Spec.ConnectionsAPIURL
 		}
 
 		if err := configureNoForkGrafanaClient(ctx, &ps); err != nil {

--- a/package/crds/grafana.crossplane.io_providerconfigs.yaml
+++ b/package/crds/grafana.crossplane.io_providerconfigs.yaml
@@ -55,6 +55,10 @@ spec:
                 description: Override the Grafana Cloud API URL from the credentials
                   reference attribute.
                 type: string
+              connectionsApiUrl:
+                description: Override the Connections API from the credentials reference
+                  attribute.
+                type: string
               credentials:
                 description: Credentials required to authenticate to this provider.
                 properties:

--- a/package/crds/grafana.crossplane.io_providerconfigs.yaml
+++ b/package/crds/grafana.crossplane.io_providerconfigs.yaml
@@ -55,6 +55,10 @@ spec:
                 description: Override the Grafana Cloud API URL from the credentials
                   reference attribute.
                 type: string
+              cloudProviderUrl:
+                description: Override the Cloud Provider API from the credentials
+                  reference attribute.
+                type: string
               connectionsApiUrl:
                 description: Override the Connections API from the credentials reference
                   attribute.
@@ -115,6 +119,10 @@ spec:
                 required:
                 - source
                 type: object
+              fleetManagementUrl:
+                description: Override the FleetManagement API from the credentials
+                  reference attribute.
+                type: string
               oncallUrl:
                 description: Override the OnCall API URL from the credentials reference
                   attribute.


### PR DESCRIPTION
This PR fixes the Crossplane provider so it can connect to the following APIs:

- Cloud provider API
- Connections API
- Fleet management API

These were added fairly recently and the Crossplane client was not supporting that yet.

Manual changes were needed in `internal/clients/grafana.go` and `apis/v1beta1/types.go`.
