### PR TITLE
remediate "credential persistence through GitHub Actions artifacts" finding from zizmor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - run: ./hack/merge-crds.sh
     - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1
       with:


### PR DESCRIPTION
Followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

Fixes this output from zizmor:

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/release.yaml:14:7
   |
14 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low
```

This follows #279 which remediated `--min-confidence medium` outputs, this is just one more small improvement