### PR TITLE
Zizmor: Dont execute cache step when we trigger the pipeline using workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -98,6 +99,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-lint-
 
       - name: Cache Go Dependencies
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .work/pkg
@@ -141,6 +143,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -148,6 +151,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-check-diff-
 
       - name: Cache Go Dependencies
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .work/pkg
@@ -187,6 +191,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -194,6 +199,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-unit-tests-
 
       - name: Cache Go Dependencies
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .work/pkg
@@ -238,6 +244,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -245,6 +252,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-unit-tests-
 
       - name: Cache Go Dependencies
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .work/pkg
@@ -310,6 +318,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -317,6 +326,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .work/pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,8 @@ jobs:
       - unit-tests
       - local-deploy
     if: needs.detect-noop.outputs.noop != 'true'
+    env:
+      INSTALL_BUILDX: ${{ github.event_name != 'workflow_dispatch' }}
 
     steps:
       - name: Setup QEMU
@@ -289,7 +291,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
-          install: true
+          install: ${{ env.INSTALL_BUILDX }}
 
       - name: Login to Upbound
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - release-*
-  pull_request: {}
 
 env:
   # Common versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - main
-      - release-*
+  pull_request: { }
+  workflow_dispatch: { }
 
 env:
   # Common versions

--- a/.github/workflows/ci_dispatch.yaml
+++ b/.github/workflows/ci_dispatch.yaml
@@ -1,13 +1,7 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - main
-      - release-*
-  pull_request: {}
+  workflow_dispatch: {}
 
 env:
   # Common versions
@@ -85,24 +79,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-lint-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
-
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
@@ -135,24 +111,6 @@ jobs:
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
 
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-check-diff-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
-
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
@@ -180,24 +138,6 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-unit-tests-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -232,24 +172,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-unit-tests-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
-
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
@@ -280,7 +202,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
-          install: true
+          install: false
 
       - name: Login to Upbound
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -303,24 +225,6 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-publish-artifacts-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/ci_dispatch.yaml
+++ b/.github/workflows/ci_dispatch.yaml
@@ -1,6 +1,7 @@
 name: CI Workflow Dispatch
 
 on:
+  pull_request: {}
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/ci_dispatch.yaml
+++ b/.github/workflows/ci_dispatch.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Workflow Dispatch
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -112,6 +113,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: 'false'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
@@ -143,6 +145,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -176,6 +179,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -230,6 +234,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -1,8 +1,12 @@
-name: CI Workflow Dispatch
+name: CI Tag
 
 on:
-  pull_request: {}
-  workflow_dispatch: {}
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+      - release-*
 
 env:
   # Common versions

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -211,7 +211,8 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
-          install: false
+          install: 'true'
+          cache-binary: 'false'
 
       - name: Login to Upbound
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       with:
         persist-credentials: false
     - run: ./hack/merge-crds.sh


### PR DESCRIPTION
Zizmor is complaining for the using of cache action in a `workflow_dispatch`. ~The change should skip cache if we are executing the pipeline using this way.~

Edit: I separated tag trigger with the other ones since it needs to do it without cache to avoid zizmor to cry.