### PR TITLE
chore(ci): update secrets handling for Upbound publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ env:
   GOLANGCI_VERSION: 'v1.64.6'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
-  # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
-  # step 'if env.XXX != ""', so we copy these to succinctly test whether
-  # credentials have been provided before trying to run steps that need them.
-  UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
-
 jobs:
   detect-noop:
     runs-on: ubuntu-24.04
@@ -312,13 +307,20 @@ jobs:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true
 
+      - name: Get Upbound Credentials from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          common_secrets: |
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_ID=upbound:access-id
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN=upbound:token
+
       - name: Login to Upbound
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         with:
           registry: xpkg.upbound.io
-          username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+          username: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID }}
+          password: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -369,5 +371,5 @@ jobs:
           path: _output/**
 
       - name: Publish Artifacts
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Explicitly set permissions for this job
     permissions:
+      id-token: write
       contents: write
     needs:
       - detect-noop

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -14,11 +14,6 @@ env:
   GOLANGCI_VERSION: 'v1.64.6'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
-  # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
-  # step 'if env.XXX != ""', so we copy these to succinctly test whether
-  # credentials have been provided before trying to run steps that need them.
-  UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
-
 jobs:
   detect-noop:
     runs-on: ubuntu-24.04
@@ -214,13 +209,20 @@ jobs:
           install: 'true'
           cache-binary: 'false'
 
+      - name: Get Upbound Credentials from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          common_secrets: |
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_ID=upbound:access-id
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN=upbound:token
+
       - name: Login to Upbound
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         with:
           registry: xpkg.upbound.io
-          username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+          username: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID }}
+          password: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -254,5 +256,5 @@ jobs:
           path: _output/**
 
       - name: Publish Artifacts
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -186,6 +186,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Explicitly set permissions for this job
     permissions:
+      id-token: write
       contents: write
     needs:
       - detect-noop


### PR DESCRIPTION
### Description of changes

This commit updates two CI workflow files (`ci.yml` and `ci_tag.yaml`) to use the new new Upbound credentials store in vault. Changes include:
- Replacing environment variable `UPBOUND_MARKETPLACE_PUSH_ROBOT_USR` with a new pattern using Vault secrets
- Updating the `Login to Upbound` step conditions and environment variables accordingly

Part of #331 


### How has this code been tested

I would like some guidance on this effort

<!--
[contribution process]: https://git.io/fj2m9
-->
