### PR TITLE
fix(config): do not recreate resource when field is missing

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -191,7 +191,6 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "AccessPolicySelector",
 			Extractor:         computedFieldExtractor("policyId"),
 		}
-		r.TerraformCustomDiff = recreateIfAttributeMissing("token")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			cloudConfig := map[string]string{}
@@ -282,7 +281,6 @@ func Configure(p *ujconfig.Provider) {
 			RefFieldName:      "ServiceAccountRef",
 			SelectorFieldName: "ServiceAccountSelector",
 		}
-		r.TerraformCustomDiff = recreateIfAttributeMissing("key")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 
@@ -325,7 +323,6 @@ func Configure(p *ujconfig.Provider) {
 			RefFieldName:      "ServiceAccountRef",
 			SelectorFieldName: "ServiceAccountSelector",
 		}
-		r.TerraformCustomDiff = recreateIfAttributeMissing("key")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 
@@ -508,7 +505,6 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "CloudStackSelector",
 			Extractor:         computedFieldExtractor("id"),
 		}
-		r.TerraformCustomDiff = recreateIfAttributeMissing("sm_access_token")
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 
@@ -571,22 +567,4 @@ func Configure(p *ujconfig.Provider) {
 			SelectorFieldName: "ProjectSelector",
 		}
 	})
-}
-
-func recreateIfAttributeMissing(attribute string) ujconfig.CustomDiff {
-	return func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-		if state == nil {
-			return diff, nil
-		}
-
-		// The attribute may not be returned in the state, so we need to recreate the resource if it is missing
-		if _, ok := state.Attributes[attribute]; !ok {
-			if diff == nil {
-				diff = &terraform.InstanceDiff{}
-			}
-			diff.DestroyTainted = true
-		}
-
-		return diff, nil
-	}
 }


### PR DESCRIPTION
This process triggers recreating the resource on every pod restart,
breaking processes that rely on this secret and sometimes getting stuck
recreating.

fixes #178

It might surface the bug from #135 again
