### PR TITLE
AlertEnrichment: fix SingleNestedBlock block conversion

### DIFF
--- a/apis/alerting/v1alpha1/zz_alertenrichmentv1beta1_types.go
+++ b/apis/alerting/v1alpha1/zz_alertenrichmentv1beta1_types.go
@@ -16,41 +16,41 @@ import (
 type AlertenrichmentV1Beta1InitParameters struct {
 
 	// The metadata of the resource.
-	Metadata []MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertenrichmentV1Beta1Observation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// The metadata of the resource.
-	Metadata []MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertenrichmentV1Beta1Parameters struct {
 
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AnnotationMatchersInitParameters struct {
@@ -154,13 +154,13 @@ type AssistantInvestigationsParameters struct {
 type ConditionalInitParameters struct {
 
 	// Steps when condition is false.
-	Else []ElseInitParameters `json:"else,omitempty" tf:"else,omitempty"`
+	Else *ElseInitParameters `json:"else,omitempty" tf:"else,omitempty"`
 
 	// Condition to evaluate.
-	If []IfInitParameters `json:"if,omitempty" tf:"if,omitempty"`
+	If *IfInitParameters `json:"if,omitempty" tf:"if,omitempty"`
 
 	// Steps when condition is true.
-	Then []ThenInitParameters `json:"then,omitempty" tf:"then,omitempty"`
+	Then *ThenInitParameters `json:"then,omitempty" tf:"then,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -169,13 +169,13 @@ type ConditionalInitParameters struct {
 type ConditionalObservation struct {
 
 	// Steps when condition is false.
-	Else []ElseObservation `json:"else,omitempty" tf:"else,omitempty"`
+	Else *ElseObservation `json:"else,omitempty" tf:"else,omitempty"`
 
 	// Condition to evaluate.
-	If []IfObservation `json:"if,omitempty" tf:"if,omitempty"`
+	If *IfObservation `json:"if,omitempty" tf:"if,omitempty"`
 
 	// Steps when condition is true.
-	Then []ThenObservation `json:"then,omitempty" tf:"then,omitempty"`
+	Then *ThenObservation `json:"then,omitempty" tf:"then,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -185,15 +185,15 @@ type ConditionalParameters struct {
 
 	// Steps when condition is false.
 	// +kubebuilder:validation:Optional
-	Else []ElseParameters `json:"else,omitempty" tf:"else,omitempty"`
+	Else *ElseParameters `json:"else,omitempty" tf:"else,omitempty"`
 
 	// Condition to evaluate.
 	// +kubebuilder:validation:Optional
-	If []IfParameters `json:"if,omitempty" tf:"if,omitempty"`
+	If *IfParameters `json:"if,omitempty" tf:"if,omitempty"`
 
 	// Steps when condition is true.
 	// +kubebuilder:validation:Optional
-	Then []ThenParameters `json:"then,omitempty" tf:"then,omitempty"`
+	Then *ThenParameters `json:"then,omitempty" tf:"then,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	// +kubebuilder:validation:Optional
@@ -222,10 +222,10 @@ type DataSourceConditionParameters struct {
 type DataSourceInitParameters struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []LogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *LogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []RawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *RawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -283,10 +283,10 @@ type DataSourceLogsQueryParameters struct {
 type DataSourceObservation struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []LogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *LogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []RawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *RawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -296,11 +296,11 @@ type DataSourceParameters struct {
 
 	// Logs query configuration for querying log data sources.
 	// +kubebuilder:validation:Optional
-	LogsQuery []LogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *LogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
 	// +kubebuilder:validation:Optional
-	RawQuery []RawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *RawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	// +kubebuilder:validation:Optional
@@ -353,80 +353,80 @@ type ElseParameters struct {
 type ElseStepInitParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []StepAssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *StepAssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []StepAssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *StepAssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []StepAssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *StepAssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []DataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *DataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []ExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *ExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []ExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *ExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []SiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type ElseStepObservation struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []StepAssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *StepAssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []StepAssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *StepAssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []StepAssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *StepAssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []DataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *DataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []ExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *ExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []ExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
+	External *ExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []SiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type ElseStepParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
 	// +kubebuilder:validation:Optional
-	Asserts []StepAssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *StepAssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
 	// +kubebuilder:validation:Optional
-	Assign []StepAssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *StepAssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
 	// +kubebuilder:validation:Optional
-	AssistantInvestigations []StepAssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *StepAssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
 	// +kubebuilder:validation:Optional
-	DataSource []DataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *DataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
 	// +kubebuilder:validation:Optional
-	Explain []ExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *ExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
 	// +kubebuilder:validation:Optional
-	External []ExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *ExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
 	// +kubebuilder:validation:Optional
-	Sift []SiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type ExplainInitParameters struct {
@@ -521,7 +521,7 @@ type IfInitParameters struct {
 	AnnotationMatchers []IfAnnotationMatchersInitParameters `json:"annotationMatchers,omitempty" tf:"annotation_matchers,omitempty"`
 
 	// Data source condition.
-	DataSourceCondition []DataSourceConditionInitParameters `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
+	DataSourceCondition *DataSourceConditionInitParameters `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
 
 	// Label matchers for the condition.
 	LabelMatchers []IfLabelMatchersInitParameters `json:"labelMatchers,omitempty" tf:"label_matchers,omitempty"`
@@ -561,7 +561,7 @@ type IfObservation struct {
 	AnnotationMatchers []IfAnnotationMatchersObservation `json:"annotationMatchers,omitempty" tf:"annotation_matchers,omitempty"`
 
 	// Data source condition.
-	DataSourceCondition []DataSourceConditionObservation `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
+	DataSourceCondition *DataSourceConditionObservation `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
 
 	// Label matchers for the condition.
 	LabelMatchers []IfLabelMatchersObservation `json:"labelMatchers,omitempty" tf:"label_matchers,omitempty"`
@@ -575,7 +575,7 @@ type IfParameters struct {
 
 	// Data source condition.
 	// +kubebuilder:validation:Optional
-	DataSourceCondition []DataSourceConditionParameters `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
+	DataSourceCondition *DataSourceConditionParameters `json:"dataSourceCondition,omitempty" tf:"data_source_condition,omitempty"`
 
 	// Label matchers for the condition.
 	// +kubebuilder:validation:Optional
@@ -846,10 +846,10 @@ type SpecParameters struct {
 type SpecStepDataSourceInitParameters struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []StepDataSourceLogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *StepDataSourceLogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []StepDataSourceRawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *StepDataSourceRawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -858,10 +858,10 @@ type SpecStepDataSourceInitParameters struct {
 type SpecStepDataSourceObservation struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []StepDataSourceLogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *StepDataSourceLogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []StepDataSourceRawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *StepDataSourceRawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -871,11 +871,11 @@ type SpecStepDataSourceParameters struct {
 
 	// Logs query configuration for querying log data sources.
 	// +kubebuilder:validation:Optional
-	LogsQuery []StepDataSourceLogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *StepDataSourceLogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
 	// +kubebuilder:validation:Optional
-	RawQuery []StepDataSourceRawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *StepDataSourceRawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	// +kubebuilder:validation:Optional
@@ -1032,10 +1032,10 @@ type StepAssistantInvestigationsParameters struct {
 type StepDataSourceInitParameters struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []DataSourceLogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *DataSourceLogsQueryInitParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []DataSourceRawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *DataSourceRawQueryInitParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -1093,10 +1093,10 @@ type StepDataSourceLogsQueryParameters struct {
 type StepDataSourceObservation struct {
 
 	// Logs query configuration for querying log data sources.
-	LogsQuery []DataSourceLogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *DataSourceLogsQueryObservation `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
-	RawQuery []DataSourceRawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *DataSourceRawQueryObservation `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	Timeout *string `json:"timeout,omitempty" tf:"timeout,omitempty"`
@@ -1106,11 +1106,11 @@ type StepDataSourceParameters struct {
 
 	// Logs query configuration for querying log data sources.
 	// +kubebuilder:validation:Optional
-	LogsQuery []DataSourceLogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
+	LogsQuery *DataSourceLogsQueryParameters `json:"logsQuery,omitempty" tf:"logs_query,omitempty"`
 
 	// Raw query configuration for advanced data source queries.
 	// +kubebuilder:validation:Optional
-	RawQuery []DataSourceRawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
+	RawQuery *DataSourceRawQueryParameters `json:"rawQuery,omitempty" tf:"raw_query,omitempty"`
 
 	// Maximum execution time (e.g., '30s', '1m')
 	// +kubebuilder:validation:Optional
@@ -1207,90 +1207,90 @@ type StepExternalParameters struct {
 type StepInitParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []AssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *AssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []AssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *AssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []AssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *AssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Conditional step with if/then/else.
-	Conditional []ConditionalInitParameters `json:"conditional,omitempty" tf:"conditional,omitempty"`
+	Conditional *ConditionalInitParameters `json:"conditional,omitempty" tf:"conditional,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []SpecStepDataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *SpecStepDataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []SpecStepExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *SpecStepExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []SpecStepExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *SpecStepExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []SpecStepSiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SpecStepSiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type StepObservation struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []AssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *AssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []AssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *AssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []AssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *AssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Conditional step with if/then/else.
-	Conditional []ConditionalObservation `json:"conditional,omitempty" tf:"conditional,omitempty"`
+	Conditional *ConditionalObservation `json:"conditional,omitempty" tf:"conditional,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []SpecStepDataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *SpecStepDataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []SpecStepExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *SpecStepExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []SpecStepExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
+	External *SpecStepExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []SpecStepSiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SpecStepSiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type StepParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
 	// +kubebuilder:validation:Optional
-	Asserts []AssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *AssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
 	// +kubebuilder:validation:Optional
-	Assign []AssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *AssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
 	// +kubebuilder:validation:Optional
-	AssistantInvestigations []AssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *AssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Conditional step with if/then/else.
 	// +kubebuilder:validation:Optional
-	Conditional []ConditionalParameters `json:"conditional,omitempty" tf:"conditional,omitempty"`
+	Conditional *ConditionalParameters `json:"conditional,omitempty" tf:"conditional,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
 	// +kubebuilder:validation:Optional
-	DataSource []SpecStepDataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *SpecStepDataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
 	// +kubebuilder:validation:Optional
-	Explain []SpecStepExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *SpecStepExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
 	// +kubebuilder:validation:Optional
-	External []SpecStepExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *SpecStepExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
 	// +kubebuilder:validation:Optional
-	Sift []SpecStepSiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *SpecStepSiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type StepSiftInitParameters struct {
@@ -1399,80 +1399,80 @@ type ThenStepAssistantInvestigationsParameters struct {
 type ThenStepInitParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []ThenStepAssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *ThenStepAssertsInitParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []ThenStepAssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *ThenStepAssignInitParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []ThenStepAssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *ThenStepAssistantInvestigationsInitParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []StepDataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *StepDataSourceInitParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []StepExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *StepExplainInitParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []StepExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *StepExternalInitParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []StepSiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *StepSiftInitParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type ThenStepObservation struct {
 
 	// Integrate with Grafana Asserts for enrichment.
-	Asserts []ThenStepAssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *ThenStepAssertsObservation `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
-	Assign []ThenStepAssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *ThenStepAssignObservation `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
-	AssistantInvestigations []ThenStepAssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *ThenStepAssistantInvestigationsObservation `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
-	DataSource []StepDataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *StepDataSourceObservation `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
-	Explain []StepExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *StepExplainObservation `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
-	External []StepExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
+	External *StepExternalObservation `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
-	Sift []StepSiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *StepSiftObservation `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 type ThenStepParameters struct {
 
 	// Integrate with Grafana Asserts for enrichment.
 	// +kubebuilder:validation:Optional
-	Asserts []ThenStepAssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
+	Asserts *ThenStepAssertsParameters `json:"asserts,omitempty" tf:"asserts,omitempty"`
 
 	// Assign annotations to an alert.
 	// +kubebuilder:validation:Optional
-	Assign []ThenStepAssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
+	Assign *ThenStepAssignParameters `json:"assign,omitempty" tf:"assign,omitempty"`
 
 	// Use AI assistant to investigate alerts and add insights.
 	// +kubebuilder:validation:Optional
-	AssistantInvestigations []ThenStepAssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
+	AssistantInvestigations *ThenStepAssistantInvestigationsParameters `json:"assistantInvestigations,omitempty" tf:"assistant_investigations,omitempty"`
 
 	// Query Grafana data sources and add results to alerts.
 	// +kubebuilder:validation:Optional
-	DataSource []StepDataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
+	DataSource *StepDataSourceParameters `json:"dataSource,omitempty" tf:"data_source,omitempty"`
 
 	// Generate AI explanation and store in an annotation.
 	// +kubebuilder:validation:Optional
-	Explain []StepExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
+	Explain *StepExplainParameters `json:"explain,omitempty" tf:"explain,omitempty"`
 
 	// Call an external HTTP service for enrichment.
 	// +kubebuilder:validation:Optional
-	External []StepExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
+	External *StepExternalParameters `json:"external,omitempty" tf:"external,omitempty"`
 
 	// Analyze alerts for patterns and insights.
 	// +kubebuilder:validation:Optional
-	Sift []StepSiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
+	Sift *StepSiftParameters `json:"sift,omitempty" tf:"sift,omitempty"`
 }
 
 // AlertenrichmentV1Beta1Spec defines the desired state of AlertenrichmentV1Beta1

--- a/apis/alerting/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/alerting/v1alpha1/zz_generated.deepcopy.go
@@ -45,24 +45,18 @@ func (in *AlertenrichmentV1Beta1InitParameters) DeepCopyInto(out *Alertenrichmen
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -118,24 +112,18 @@ func (in *AlertenrichmentV1Beta1Observation) DeepCopyInto(out *AlertenrichmentV1
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -154,24 +142,18 @@ func (in *AlertenrichmentV1Beta1Parameters) DeepCopyInto(out *AlertenrichmentV1B
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -669,24 +651,18 @@ func (in *ConditionalInitParameters) DeepCopyInto(out *ConditionalInitParameters
 	*out = *in
 	if in.Else != nil {
 		in, out := &in.Else, &out.Else
-		*out = make([]ElseInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ElseInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.If != nil {
 		in, out := &in.If, &out.If
-		*out = make([]IfInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(IfInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Then != nil {
 		in, out := &in.Then, &out.Then
-		*out = make([]ThenInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -710,24 +686,18 @@ func (in *ConditionalObservation) DeepCopyInto(out *ConditionalObservation) {
 	*out = *in
 	if in.Else != nil {
 		in, out := &in.Else, &out.Else
-		*out = make([]ElseObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ElseObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.If != nil {
 		in, out := &in.If, &out.If
-		*out = make([]IfObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(IfObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Then != nil {
 		in, out := &in.Then, &out.Then
-		*out = make([]ThenObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -751,24 +721,18 @@ func (in *ConditionalParameters) DeepCopyInto(out *ConditionalParameters) {
 	*out = *in
 	if in.Else != nil {
 		in, out := &in.Else, &out.Else
-		*out = make([]ElseParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ElseParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.If != nil {
 		in, out := &in.If, &out.If
-		*out = make([]IfParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(IfParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Then != nil {
 		in, out := &in.Then, &out.Then
-		*out = make([]ThenParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -1628,17 +1592,13 @@ func (in *DataSourceInitParameters) DeepCopyInto(out *DataSourceInitParameters) 
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]LogsQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(LogsQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]RawQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RawQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -1767,17 +1727,13 @@ func (in *DataSourceObservation) DeepCopyInto(out *DataSourceObservation) {
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]LogsQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(LogsQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]RawQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RawQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -1801,17 +1757,13 @@ func (in *DataSourceParameters) DeepCopyInto(out *DataSourceParameters) {
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]LogsQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(LogsQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]RawQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RawQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -2257,52 +2209,38 @@ func (in *ElseStepInitParameters) DeepCopyInto(out *ElseStepInitParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]StepAssertsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssertsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]StepAssignInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssignInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]StepAssistantInvestigationsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssistantInvestigationsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]DataSourceInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]ExplainInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExplainInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]ExternalInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExternalInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SiftInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SiftInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -2321,52 +2259,38 @@ func (in *ElseStepObservation) DeepCopyInto(out *ElseStepObservation) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]StepAssertsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssertsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]StepAssignObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssignObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]StepAssistantInvestigationsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssistantInvestigationsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]DataSourceObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]ExplainObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExplainObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]ExternalObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExternalObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SiftObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SiftObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -2385,52 +2309,38 @@ func (in *ElseStepParameters) DeepCopyInto(out *ElseStepParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]StepAssertsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssertsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]StepAssignParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssignParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]StepAssistantInvestigationsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepAssistantInvestigationsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]DataSourceParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]ExplainParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExplainParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]ExternalParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ExternalParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SiftParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SiftParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -3121,10 +3031,8 @@ func (in *IfInitParameters) DeepCopyInto(out *IfInitParameters) {
 	}
 	if in.DataSourceCondition != nil {
 		in, out := &in.DataSourceCondition, &out.DataSourceCondition
-		*out = make([]DataSourceConditionInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceConditionInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LabelMatchers != nil {
 		in, out := &in.LabelMatchers, &out.LabelMatchers
@@ -3247,10 +3155,8 @@ func (in *IfObservation) DeepCopyInto(out *IfObservation) {
 	}
 	if in.DataSourceCondition != nil {
 		in, out := &in.DataSourceCondition, &out.DataSourceCondition
-		*out = make([]DataSourceConditionObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceConditionObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LabelMatchers != nil {
 		in, out := &in.LabelMatchers, &out.LabelMatchers
@@ -3283,10 +3189,8 @@ func (in *IfParameters) DeepCopyInto(out *IfParameters) {
 	}
 	if in.DataSourceCondition != nil {
 		in, out := &in.DataSourceCondition, &out.DataSourceCondition
-		*out = make([]DataSourceConditionParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceConditionParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LabelMatchers != nil {
 		in, out := &in.LabelMatchers, &out.LabelMatchers
@@ -9996,17 +9900,13 @@ func (in *SpecStepDataSourceInitParameters) DeepCopyInto(out *SpecStepDataSource
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]StepDataSourceLogsQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceLogsQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]StepDataSourceRawQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceRawQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10030,17 +9930,13 @@ func (in *SpecStepDataSourceObservation) DeepCopyInto(out *SpecStepDataSourceObs
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]StepDataSourceLogsQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceLogsQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]StepDataSourceRawQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceRawQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10064,17 +9960,13 @@ func (in *SpecStepDataSourceParameters) DeepCopyInto(out *SpecStepDataSourcePara
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]StepDataSourceLogsQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceLogsQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]StepDataSourceRawQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceRawQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10536,17 +10428,13 @@ func (in *StepDataSourceInitParameters) DeepCopyInto(out *StepDataSourceInitPara
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]DataSourceLogsQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceLogsQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]DataSourceRawQueryInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceRawQueryInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10675,17 +10563,13 @@ func (in *StepDataSourceObservation) DeepCopyInto(out *StepDataSourceObservation
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]DataSourceLogsQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceLogsQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]DataSourceRawQueryObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceRawQueryObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10709,17 +10593,13 @@ func (in *StepDataSourceParameters) DeepCopyInto(out *StepDataSourceParameters) 
 	*out = *in
 	if in.LogsQuery != nil {
 		in, out := &in.LogsQuery, &out.LogsQuery
-		*out = make([]DataSourceLogsQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceLogsQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RawQuery != nil {
 		in, out := &in.RawQuery, &out.RawQuery
-		*out = make([]DataSourceRawQueryParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(DataSourceRawQueryParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
@@ -10968,59 +10848,43 @@ func (in *StepInitParameters) DeepCopyInto(out *StepInitParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]AssertsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssertsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]AssignInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssignInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]AssistantInvestigationsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssistantInvestigationsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Conditional != nil {
 		in, out := &in.Conditional, &out.Conditional
-		*out = make([]ConditionalInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ConditionalInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]SpecStepDataSourceInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepDataSourceInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]SpecStepExplainInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExplainInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]SpecStepExternalInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExternalInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SpecStepSiftInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepSiftInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -11039,59 +10903,43 @@ func (in *StepObservation) DeepCopyInto(out *StepObservation) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]AssertsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssertsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]AssignObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssignObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]AssistantInvestigationsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssistantInvestigationsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Conditional != nil {
 		in, out := &in.Conditional, &out.Conditional
-		*out = make([]ConditionalObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ConditionalObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]SpecStepDataSourceObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepDataSourceObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]SpecStepExplainObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExplainObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]SpecStepExternalObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExternalObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SpecStepSiftObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepSiftObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -11110,59 +10958,43 @@ func (in *StepParameters) DeepCopyInto(out *StepParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]AssertsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssertsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]AssignParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssignParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]AssistantInvestigationsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AssistantInvestigationsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Conditional != nil {
 		in, out := &in.Conditional, &out.Conditional
-		*out = make([]ConditionalParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ConditionalParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]SpecStepDataSourceParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepDataSourceParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]SpecStepExplainParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExplainParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]SpecStepExternalParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepExternalParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]SpecStepSiftParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecStepSiftParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -11951,52 +11783,38 @@ func (in *ThenStepInitParameters) DeepCopyInto(out *ThenStepInitParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]ThenStepAssertsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssertsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]ThenStepAssignInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssignInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]ThenStepAssistantInvestigationsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssistantInvestigationsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]StepDataSourceInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]StepExplainInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExplainInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]StepExternalInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExternalInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]StepSiftInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepSiftInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -12015,52 +11833,38 @@ func (in *ThenStepObservation) DeepCopyInto(out *ThenStepObservation) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]ThenStepAssertsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssertsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]ThenStepAssignObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssignObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]ThenStepAssistantInvestigationsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssistantInvestigationsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]StepDataSourceObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]StepExplainObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExplainObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]StepExternalObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExternalObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]StepSiftObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepSiftObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -12079,52 +11883,38 @@ func (in *ThenStepParameters) DeepCopyInto(out *ThenStepParameters) {
 	*out = *in
 	if in.Asserts != nil {
 		in, out := &in.Asserts, &out.Asserts
-		*out = make([]ThenStepAssertsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssertsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Assign != nil {
 		in, out := &in.Assign, &out.Assign
-		*out = make([]ThenStepAssignParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssignParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AssistantInvestigations != nil {
 		in, out := &in.AssistantInvestigations, &out.AssistantInvestigations
-		*out = make([]ThenStepAssistantInvestigationsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(ThenStepAssistantInvestigationsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DataSource != nil {
 		in, out := &in.DataSource, &out.DataSource
-		*out = make([]StepDataSourceParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepDataSourceParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Explain != nil {
 		in, out := &in.Explain, &out.Explain
-		*out = make([]StepExplainParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExplainParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		*out = make([]StepExternalParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepExternalParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Sift != nil {
 		in, out := &in.Sift, &out.Sift
-		*out = make([]StepSiftParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(StepSiftParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -88,6 +88,15 @@ func ConfigureOnCallRefsAndSelectors(p *ujconfig.Provider) {
 		// r.References["slack.user_group_id"] = oncallUserGroupRef
 	})
 
+	p.AddResourceConfigurator(
+		"grafana_apps_alertenrichment_alertenrichment_v1beta1",
+		func(r *ujconfig.Resource) {
+			if err := ujconfig.TraverseSchemas(r.Name, r, &ujconfig.SingletonListEmbedder{}); err != nil {
+				panic(fmt.Errorf("failed to configure singleton blocks for %s: %w", r.Name, err))
+			}
+		},
+	)
+
 	// NOTE: the following refs will not work as Terraform datasources are not translated to Crossplane resources
 	// the workaround is to use the Terraform provider for Crossplane to use the datasources directly
 	// https://github.com/crossplane/crossplane/blob/master/design/design-doc-observe-only-resources.md

--- a/package/crds/alerting.grafana.crossplane.io_alertenrichmentv1beta1s.yaml
+++ b/package/crds/alerting.grafana.crossplane.io_alertenrichmentv1beta1s.yaml
@@ -75,565 +75,477 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        alertRuleUids:
-                          description: UIDs of alert rules this enrichment applies
-                            to. If empty, applies to all alert rules.
-                          items:
-                            type: string
-                          type: array
-                        annotationMatchers:
-                          description: 'Annotation matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, annotation key to match), ''value'' (string,
-                            annotation value to compare against, supports regex for
-                            =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        description:
-                          description: Description of the alert enrichment.
+                    properties:
+                      alertRuleUids:
+                        description: UIDs of alert rules this enrichment applies to.
+                          If empty, applies to all alert rules.
+                        items:
                           type: string
-                        labelMatchers:
-                          description: 'Label matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, label key to match), ''value'' (string, label
-                            value to compare against, supports regex for =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        receivers:
-                          description: Receiver names to match. If empty, applies
-                            to all receivers.
-                          items:
-                            type: string
-                          type: array
-                        step:
-                          description: Enrichment step. Can be repeated multiple times
-                            to define a sequence of steps. Each step must contain
-                            exactly one enrichment block.
-                          items:
-                            properties:
-                              asserts:
-                                description: Integrate with Grafana Asserts for enrichment.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                        type: array
+                      annotationMatchers:
+                        description: 'Annotation matchers that an alert must satisfy
+                          for this enrichment to apply. Each matcher is an object
+                          with: ''type'' (string, one of: =, !=, =~, !~), ''name''
+                          (string, annotation key to match), ''value'' (string, annotation
+                          value to compare against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      description:
+                        description: Description of the alert enrichment.
+                        type: string
+                      labelMatchers:
+                        description: 'Label matchers that an alert must satisfy for
+                          this enrichment to apply. Each matcher is an object with:
+                          ''type'' (string, one of: =, !=, =~, !~), ''name'' (string,
+                          label key to match), ''value'' (string, label value to compare
+                          against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      receivers:
+                        description: Receiver names to match. If empty, applies to
+                          all receivers.
+                        items:
+                          type: string
+                        type: array
+                      step:
+                        description: Enrichment step. Can be repeated multiple times
+                          to define a sequence of steps. Each step must contain exactly
+                          one enrichment block.
+                        items:
+                          properties:
+                            asserts:
+                              description: Integrate with Grafana Asserts for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assign:
+                              description: Assign annotations to an alert.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map of annotation names to values to
+                                    set on matching alerts.
                                   type: object
-                                type: array
-                              assign:
-                                description: Assign annotations to an alert.
-                                items:
+                                  x-kubernetes-map-type: granular
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assistantInvestigations:
+                              description: Use AI assistant to investigate alerts
+                                and add insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            conditional:
+                              description: Conditional step with if/then/else.
+                              properties:
+                                else:
+                                  description: Steps when condition is false.
                                   properties:
-                                    annotations:
-                                      additionalProperties:
-                                        type: string
-                                      description: Map of annotation names to values
-                                        to set on matching alerts.
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                if:
+                                  description: Condition to evaluate.
+                                  properties:
+                                    annotationMatchers:
+                                      description: Annotation matchers for the condition.
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          type:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    dataSourceCondition:
+                                      description: Data source condition.
+                                      properties:
+                                        request:
+                                          description: Data source request payload.
+                                          type: string
                                       type: object
-                                      x-kubernetes-map-type: granular
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              assistantInvestigations:
-                                description: Use AI assistant to investigate alerts
-                                  and add insights.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              conditional:
-                                description: Conditional step with if/then/else.
-                                items:
-                                  properties:
-                                    else:
-                                      description: Steps when condition is false.
+                                    labelMatchers:
+                                      description: Label matchers for the condition.
                                       items:
                                         properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    if:
-                                      description: Condition to evaluate.
-                                      items:
-                                        properties:
-                                          annotationMatchers:
-                                            description: Annotation matchers for the
-                                              condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          dataSourceCondition:
-                                            description: Data source condition.
-                                            items:
-                                              properties:
-                                                request:
-                                                  description: Data source request
-                                                    payload.
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          labelMatchers:
-                                            description: Label matchers for the condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    then:
-                                      description: Steps when condition is true.
-                                      items:
-                                        properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              dataSource:
-                                description: Query Grafana data sources and add results
-                                  to alerts.
-                                items:
-                                  properties:
-                                    logsQuery:
-                                      description: Logs query configuration for querying
-                                        log data sources.
-                                      items:
-                                        properties:
-                                          dataSourceType:
-                                            description: Data source type (e.g., 'loki').
+                                          name:
                                             type: string
-                                          dataSourceUid:
-                                            description: UID of the data source to
-                                              query.
+                                          type:
                                             type: string
-                                          expr:
-                                            description: Log query expression to execute.
-                                            type: string
-                                          maxLines:
-                                            description: Maximum number of log lines
-                                              to include. Defaults to 3.
-                                            type: number
-                                        type: object
-                                      type: array
-                                    rawQuery:
-                                      description: Raw query configuration for advanced
-                                        data source queries.
-                                      items:
-                                        properties:
-                                          refId:
-                                            description: Reference ID for correlating
-                                              queries.
-                                            type: string
-                                          request:
-                                            description: Raw request payload for the
-                                              data source query.
+                                          value:
                                             type: string
                                         type: object
                                       type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
                                   type: object
-                                type: array
-                              explain:
-                                description: Generate AI explanation and store in
-                                  an annotation.
-                                items:
+                                then:
+                                  description: Steps when condition is true.
                                   properties:
-                                    annotation:
-                                      description: Annotation name to set the explanation
-                                        in. Defaults to 'ai_explanation'.
-                                      type: string
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
                                   type: object
-                                type: array
-                              external:
-                                description: Call an external HTTP service for enrichment.
-                                items:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            dataSource:
+                              description: Query Grafana data sources and add results
+                                to alerts.
+                              properties:
+                                logsQuery:
+                                  description: Logs query configuration for querying
+                                    log data sources.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    dataSourceType:
+                                      description: Data source type (e.g., 'loki').
                                       type: string
-                                    url:
-                                      description: HTTP endpoint URL to call for enrichment
+                                    dataSourceUid:
+                                      description: UID of the data source to query.
                                       type: string
+                                    expr:
+                                      description: Log query expression to execute.
+                                      type: string
+                                    maxLines:
+                                      description: Maximum number of log lines to
+                                        include. Defaults to 3.
+                                      type: number
                                   type: object
-                                type: array
-                              sift:
-                                description: Analyze alerts for patterns and insights.
-                                items:
+                                rawQuery:
+                                  description: Raw query configuration for advanced
+                                    data source queries.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    refId:
+                                      description: Reference ID for correlating queries.
+                                      type: string
+                                    request:
+                                      description: Raw request payload for the data
+                                        source query.
                                       type: string
                                   type: object
-                                type: array
-                            type: object
-                          type: array
-                        title:
-                          description: The title of the alert enrichment.
-                          type: string
-                      type: object
-                    type: array
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            explain:
+                              description: Generate AI explanation and store in an
+                                annotation.
+                              properties:
+                                annotation:
+                                  description: Annotation name to set the explanation
+                                    in. Defaults to 'ai_explanation'.
+                                  type: string
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            external:
+                              description: Call an external HTTP service for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                                url:
+                                  description: HTTP endpoint URL to call for enrichment
+                                  type: string
+                              type: object
+                            sift:
+                              description: Analyze alerts for patterns and insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      title:
+                        description: The title of the alert enrichment.
+                        type: string
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -650,565 +562,477 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        alertRuleUids:
-                          description: UIDs of alert rules this enrichment applies
-                            to. If empty, applies to all alert rules.
-                          items:
-                            type: string
-                          type: array
-                        annotationMatchers:
-                          description: 'Annotation matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, annotation key to match), ''value'' (string,
-                            annotation value to compare against, supports regex for
-                            =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        description:
-                          description: Description of the alert enrichment.
+                    properties:
+                      alertRuleUids:
+                        description: UIDs of alert rules this enrichment applies to.
+                          If empty, applies to all alert rules.
+                        items:
                           type: string
-                        labelMatchers:
-                          description: 'Label matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, label key to match), ''value'' (string, label
-                            value to compare against, supports regex for =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        receivers:
-                          description: Receiver names to match. If empty, applies
-                            to all receivers.
-                          items:
-                            type: string
-                          type: array
-                        step:
-                          description: Enrichment step. Can be repeated multiple times
-                            to define a sequence of steps. Each step must contain
-                            exactly one enrichment block.
-                          items:
-                            properties:
-                              asserts:
-                                description: Integrate with Grafana Asserts for enrichment.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                        type: array
+                      annotationMatchers:
+                        description: 'Annotation matchers that an alert must satisfy
+                          for this enrichment to apply. Each matcher is an object
+                          with: ''type'' (string, one of: =, !=, =~, !~), ''name''
+                          (string, annotation key to match), ''value'' (string, annotation
+                          value to compare against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      description:
+                        description: Description of the alert enrichment.
+                        type: string
+                      labelMatchers:
+                        description: 'Label matchers that an alert must satisfy for
+                          this enrichment to apply. Each matcher is an object with:
+                          ''type'' (string, one of: =, !=, =~, !~), ''name'' (string,
+                          label key to match), ''value'' (string, label value to compare
+                          against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      receivers:
+                        description: Receiver names to match. If empty, applies to
+                          all receivers.
+                        items:
+                          type: string
+                        type: array
+                      step:
+                        description: Enrichment step. Can be repeated multiple times
+                          to define a sequence of steps. Each step must contain exactly
+                          one enrichment block.
+                        items:
+                          properties:
+                            asserts:
+                              description: Integrate with Grafana Asserts for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assign:
+                              description: Assign annotations to an alert.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map of annotation names to values to
+                                    set on matching alerts.
                                   type: object
-                                type: array
-                              assign:
-                                description: Assign annotations to an alert.
-                                items:
+                                  x-kubernetes-map-type: granular
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assistantInvestigations:
+                              description: Use AI assistant to investigate alerts
+                                and add insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            conditional:
+                              description: Conditional step with if/then/else.
+                              properties:
+                                else:
+                                  description: Steps when condition is false.
                                   properties:
-                                    annotations:
-                                      additionalProperties:
-                                        type: string
-                                      description: Map of annotation names to values
-                                        to set on matching alerts.
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                if:
+                                  description: Condition to evaluate.
+                                  properties:
+                                    annotationMatchers:
+                                      description: Annotation matchers for the condition.
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          type:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    dataSourceCondition:
+                                      description: Data source condition.
+                                      properties:
+                                        request:
+                                          description: Data source request payload.
+                                          type: string
                                       type: object
-                                      x-kubernetes-map-type: granular
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              assistantInvestigations:
-                                description: Use AI assistant to investigate alerts
-                                  and add insights.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              conditional:
-                                description: Conditional step with if/then/else.
-                                items:
-                                  properties:
-                                    else:
-                                      description: Steps when condition is false.
+                                    labelMatchers:
+                                      description: Label matchers for the condition.
                                       items:
                                         properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    if:
-                                      description: Condition to evaluate.
-                                      items:
-                                        properties:
-                                          annotationMatchers:
-                                            description: Annotation matchers for the
-                                              condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          dataSourceCondition:
-                                            description: Data source condition.
-                                            items:
-                                              properties:
-                                                request:
-                                                  description: Data source request
-                                                    payload.
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          labelMatchers:
-                                            description: Label matchers for the condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    then:
-                                      description: Steps when condition is true.
-                                      items:
-                                        properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              dataSource:
-                                description: Query Grafana data sources and add results
-                                  to alerts.
-                                items:
-                                  properties:
-                                    logsQuery:
-                                      description: Logs query configuration for querying
-                                        log data sources.
-                                      items:
-                                        properties:
-                                          dataSourceType:
-                                            description: Data source type (e.g., 'loki').
+                                          name:
                                             type: string
-                                          dataSourceUid:
-                                            description: UID of the data source to
-                                              query.
+                                          type:
                                             type: string
-                                          expr:
-                                            description: Log query expression to execute.
-                                            type: string
-                                          maxLines:
-                                            description: Maximum number of log lines
-                                              to include. Defaults to 3.
-                                            type: number
-                                        type: object
-                                      type: array
-                                    rawQuery:
-                                      description: Raw query configuration for advanced
-                                        data source queries.
-                                      items:
-                                        properties:
-                                          refId:
-                                            description: Reference ID for correlating
-                                              queries.
-                                            type: string
-                                          request:
-                                            description: Raw request payload for the
-                                              data source query.
+                                          value:
                                             type: string
                                         type: object
                                       type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
                                   type: object
-                                type: array
-                              explain:
-                                description: Generate AI explanation and store in
-                                  an annotation.
-                                items:
+                                then:
+                                  description: Steps when condition is true.
                                   properties:
-                                    annotation:
-                                      description: Annotation name to set the explanation
-                                        in. Defaults to 'ai_explanation'.
-                                      type: string
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
                                   type: object
-                                type: array
-                              external:
-                                description: Call an external HTTP service for enrichment.
-                                items:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            dataSource:
+                              description: Query Grafana data sources and add results
+                                to alerts.
+                              properties:
+                                logsQuery:
+                                  description: Logs query configuration for querying
+                                    log data sources.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    dataSourceType:
+                                      description: Data source type (e.g., 'loki').
                                       type: string
-                                    url:
-                                      description: HTTP endpoint URL to call for enrichment
+                                    dataSourceUid:
+                                      description: UID of the data source to query.
                                       type: string
+                                    expr:
+                                      description: Log query expression to execute.
+                                      type: string
+                                    maxLines:
+                                      description: Maximum number of log lines to
+                                        include. Defaults to 3.
+                                      type: number
                                   type: object
-                                type: array
-                              sift:
-                                description: Analyze alerts for patterns and insights.
-                                items:
+                                rawQuery:
+                                  description: Raw query configuration for advanced
+                                    data source queries.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    refId:
+                                      description: Reference ID for correlating queries.
+                                      type: string
+                                    request:
+                                      description: Raw request payload for the data
+                                        source query.
                                       type: string
                                   type: object
-                                type: array
-                            type: object
-                          type: array
-                        title:
-                          description: The title of the alert enrichment.
-                          type: string
-                      type: object
-                    type: array
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            explain:
+                              description: Generate AI explanation and store in an
+                                annotation.
+                              properties:
+                                annotation:
+                                  description: Annotation name to set the explanation
+                                    in. Defaults to 'ai_explanation'.
+                                  type: string
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            external:
+                              description: Call an external HTTP service for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                                url:
+                                  description: HTTP endpoint URL to call for enrichment
+                                  type: string
+                              type: object
+                            sift:
+                              description: Analyze alerts for patterns and insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      title:
+                        description: The title of the alert enrichment.
+                        type: string
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -1396,575 +1220,487 @@ spec:
                     type: string
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: The globally unique identifier of a resource,
-                            used by the API for tracking.
-                          type: string
-                        version:
-                          description: The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: The globally unique identifier of a resource,
+                          used by the API for tracking.
+                        type: string
+                      version:
+                        description: The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        alertRuleUids:
-                          description: UIDs of alert rules this enrichment applies
-                            to. If empty, applies to all alert rules.
-                          items:
-                            type: string
-                          type: array
-                        annotationMatchers:
-                          description: 'Annotation matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, annotation key to match), ''value'' (string,
-                            annotation value to compare against, supports regex for
-                            =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        description:
-                          description: Description of the alert enrichment.
+                    properties:
+                      alertRuleUids:
+                        description: UIDs of alert rules this enrichment applies to.
+                          If empty, applies to all alert rules.
+                        items:
                           type: string
-                        labelMatchers:
-                          description: 'Label matchers that an alert must satisfy
-                            for this enrichment to apply. Each matcher is an object
-                            with: ''type'' (string, one of: =, !=, =~, !~), ''name''
-                            (string, label key to match), ''value'' (string, label
-                            value to compare against, supports regex for =~/!~ operators).'
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        receivers:
-                          description: Receiver names to match. If empty, applies
-                            to all receivers.
-                          items:
-                            type: string
-                          type: array
-                        step:
-                          description: Enrichment step. Can be repeated multiple times
-                            to define a sequence of steps. Each step must contain
-                            exactly one enrichment block.
-                          items:
-                            properties:
-                              asserts:
-                                description: Integrate with Grafana Asserts for enrichment.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                        type: array
+                      annotationMatchers:
+                        description: 'Annotation matchers that an alert must satisfy
+                          for this enrichment to apply. Each matcher is an object
+                          with: ''type'' (string, one of: =, !=, =~, !~), ''name''
+                          (string, annotation key to match), ''value'' (string, annotation
+                          value to compare against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      description:
+                        description: Description of the alert enrichment.
+                        type: string
+                      labelMatchers:
+                        description: 'Label matchers that an alert must satisfy for
+                          this enrichment to apply. Each matcher is an object with:
+                          ''type'' (string, one of: =, !=, =~, !~), ''name'' (string,
+                          label key to match), ''value'' (string, label value to compare
+                          against, supports regex for =~/!~ operators).'
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      receivers:
+                        description: Receiver names to match. If empty, applies to
+                          all receivers.
+                        items:
+                          type: string
+                        type: array
+                      step:
+                        description: Enrichment step. Can be repeated multiple times
+                          to define a sequence of steps. Each step must contain exactly
+                          one enrichment block.
+                        items:
+                          properties:
+                            asserts:
+                              description: Integrate with Grafana Asserts for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assign:
+                              description: Assign annotations to an alert.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map of annotation names to values to
+                                    set on matching alerts.
                                   type: object
-                                type: array
-                              assign:
-                                description: Assign annotations to an alert.
-                                items:
+                                  x-kubernetes-map-type: granular
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            assistantInvestigations:
+                              description: Use AI assistant to investigate alerts
+                                and add insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            conditional:
+                              description: Conditional step with if/then/else.
+                              properties:
+                                else:
+                                  description: Steps when condition is false.
                                   properties:
-                                    annotations:
-                                      additionalProperties:
-                                        type: string
-                                      description: Map of annotation names to values
-                                        to set on matching alerts.
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                if:
+                                  description: Condition to evaluate.
+                                  properties:
+                                    annotationMatchers:
+                                      description: Annotation matchers for the condition.
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          type:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    dataSourceCondition:
+                                      description: Data source condition.
+                                      properties:
+                                        request:
+                                          description: Data source request payload.
+                                          type: string
                                       type: object
-                                      x-kubernetes-map-type: granular
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              assistantInvestigations:
-                                description: Use AI assistant to investigate alerts
-                                  and add insights.
-                                items:
-                                  properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              conditional:
-                                description: Conditional step with if/then/else.
-                                items:
-                                  properties:
-                                    else:
-                                      description: Steps when condition is false.
+                                    labelMatchers:
+                                      description: Label matchers for the condition.
                                       items:
                                         properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    if:
-                                      description: Condition to evaluate.
-                                      items:
-                                        properties:
-                                          annotationMatchers:
-                                            description: Annotation matchers for the
-                                              condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          dataSourceCondition:
-                                            description: Data source condition.
-                                            items:
-                                              properties:
-                                                request:
-                                                  description: Data source request
-                                                    payload.
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          labelMatchers:
-                                            description: Label matchers for the condition.
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    then:
-                                      description: Steps when condition is true.
-                                      items:
-                                        properties:
-                                          step:
-                                            items:
-                                              properties:
-                                                asserts:
-                                                  description: Integrate with Grafana
-                                                    Asserts for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assign:
-                                                  description: Assign annotations
-                                                    to an alert.
-                                                  items:
-                                                    properties:
-                                                      annotations:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: Map of annotation
-                                                          names to values to set on
-                                                          matching alerts.
-                                                        type: object
-                                                        x-kubernetes-map-type: granular
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                assistantInvestigations:
-                                                  description: Use AI assistant to
-                                                    investigate alerts and add insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                dataSource:
-                                                  description: Query Grafana data
-                                                    sources and add results to alerts.
-                                                  items:
-                                                    properties:
-                                                      logsQuery:
-                                                        description: Logs query configuration
-                                                          for querying log data sources.
-                                                        items:
-                                                          properties:
-                                                            dataSourceType:
-                                                              description: Data source
-                                                                type (e.g., 'loki').
-                                                              type: string
-                                                            dataSourceUid:
-                                                              description: UID of
-                                                                the data source to
-                                                                query.
-                                                              type: string
-                                                            expr:
-                                                              description: Log query
-                                                                expression to execute.
-                                                              type: string
-                                                            maxLines:
-                                                              description: Maximum
-                                                                number of log lines
-                                                                to include. Defaults
-                                                                to 3.
-                                                              type: number
-                                                          type: object
-                                                        type: array
-                                                      rawQuery:
-                                                        description: Raw query configuration
-                                                          for advanced data source
-                                                          queries.
-                                                        items:
-                                                          properties:
-                                                            refId:
-                                                              description: Reference
-                                                                ID for correlating
-                                                                queries.
-                                                              type: string
-                                                            request:
-                                                              description: Raw request
-                                                                payload for the data
-                                                                source query.
-                                                              type: string
-                                                          type: object
-                                                        type: array
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                explain:
-                                                  description: Generate AI explanation
-                                                    and store in an annotation.
-                                                  items:
-                                                    properties:
-                                                      annotation:
-                                                        description: Annotation name
-                                                          to set the explanation in.
-                                                          Defaults to 'ai_explanation'.
-                                                        type: string
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                external:
-                                                  description: Call an external HTTP
-                                                    service for enrichment.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                      url:
-                                                        description: HTTP endpoint
-                                                          URL to call for enrichment
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                                sift:
-                                                  description: Analyze alerts for
-                                                    patterns and insights.
-                                                  items:
-                                                    properties:
-                                                      timeout:
-                                                        description: Maximum execution
-                                                          time (e.g., '30s', '1m')
-                                                        type: string
-                                                    type: object
-                                                  type: array
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
-                                  type: object
-                                type: array
-                              dataSource:
-                                description: Query Grafana data sources and add results
-                                  to alerts.
-                                items:
-                                  properties:
-                                    logsQuery:
-                                      description: Logs query configuration for querying
-                                        log data sources.
-                                      items:
-                                        properties:
-                                          dataSourceType:
-                                            description: Data source type (e.g., 'loki').
+                                          name:
                                             type: string
-                                          dataSourceUid:
-                                            description: UID of the data source to
-                                              query.
+                                          type:
                                             type: string
-                                          expr:
-                                            description: Log query expression to execute.
-                                            type: string
-                                          maxLines:
-                                            description: Maximum number of log lines
-                                              to include. Defaults to 3.
-                                            type: number
-                                        type: object
-                                      type: array
-                                    rawQuery:
-                                      description: Raw query configuration for advanced
-                                        data source queries.
-                                      items:
-                                        properties:
-                                          refId:
-                                            description: Reference ID for correlating
-                                              queries.
-                                            type: string
-                                          request:
-                                            description: Raw request payload for the
-                                              data source query.
+                                          value:
                                             type: string
                                         type: object
                                       type: array
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
                                   type: object
-                                type: array
-                              explain:
-                                description: Generate AI explanation and store in
-                                  an annotation.
-                                items:
+                                then:
+                                  description: Steps when condition is true.
                                   properties:
-                                    annotation:
-                                      description: Annotation name to set the explanation
-                                        in. Defaults to 'ai_explanation'.
-                                      type: string
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
-                                      type: string
+                                    step:
+                                      items:
+                                        properties:
+                                          asserts:
+                                            description: Integrate with Grafana Asserts
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assign:
+                                            description: Assign annotations to an
+                                              alert.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map of annotation names
+                                                  to values to set on matching alerts.
+                                                type: object
+                                                x-kubernetes-map-type: granular
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          assistantInvestigations:
+                                            description: Use AI assistant to investigate
+                                              alerts and add insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          dataSource:
+                                            description: Query Grafana data sources
+                                              and add results to alerts.
+                                            properties:
+                                              logsQuery:
+                                                description: Logs query configuration
+                                                  for querying log data sources.
+                                                properties:
+                                                  dataSourceType:
+                                                    description: Data source type
+                                                      (e.g., 'loki').
+                                                    type: string
+                                                  dataSourceUid:
+                                                    description: UID of the data source
+                                                      to query.
+                                                    type: string
+                                                  expr:
+                                                    description: Log query expression
+                                                      to execute.
+                                                    type: string
+                                                  maxLines:
+                                                    description: Maximum number of
+                                                      log lines to include. Defaults
+                                                      to 3.
+                                                    type: number
+                                                type: object
+                                              rawQuery:
+                                                description: Raw query configuration
+                                                  for advanced data source queries.
+                                                properties:
+                                                  refId:
+                                                    description: Reference ID for
+                                                      correlating queries.
+                                                    type: string
+                                                  request:
+                                                    description: Raw request payload
+                                                      for the data source query.
+                                                    type: string
+                                                type: object
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          explain:
+                                            description: Generate AI explanation and
+                                              store in an annotation.
+                                            properties:
+                                              annotation:
+                                                description: Annotation name to set
+                                                  the explanation in. Defaults to
+                                                  'ai_explanation'.
+                                                type: string
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                          external:
+                                            description: Call an external HTTP service
+                                              for enrichment.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                              url:
+                                                description: HTTP endpoint URL to
+                                                  call for enrichment
+                                                type: string
+                                            type: object
+                                          sift:
+                                            description: Analyze alerts for patterns
+                                              and insights.
+                                            properties:
+                                              timeout:
+                                                description: Maximum execution time
+                                                  (e.g., '30s', '1m')
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
                                   type: object
-                                type: array
-                              external:
-                                description: Call an external HTTP service for enrichment.
-                                items:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            dataSource:
+                              description: Query Grafana data sources and add results
+                                to alerts.
+                              properties:
+                                logsQuery:
+                                  description: Logs query configuration for querying
+                                    log data sources.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    dataSourceType:
+                                      description: Data source type (e.g., 'loki').
                                       type: string
-                                    url:
-                                      description: HTTP endpoint URL to call for enrichment
+                                    dataSourceUid:
+                                      description: UID of the data source to query.
                                       type: string
+                                    expr:
+                                      description: Log query expression to execute.
+                                      type: string
+                                    maxLines:
+                                      description: Maximum number of log lines to
+                                        include. Defaults to 3.
+                                      type: number
                                   type: object
-                                type: array
-                              sift:
-                                description: Analyze alerts for patterns and insights.
-                                items:
+                                rawQuery:
+                                  description: Raw query configuration for advanced
+                                    data source queries.
                                   properties:
-                                    timeout:
-                                      description: Maximum execution time (e.g., '30s',
-                                        '1m')
+                                    refId:
+                                      description: Reference ID for correlating queries.
+                                      type: string
+                                    request:
+                                      description: Raw request payload for the data
+                                        source query.
                                       type: string
                                   type: object
-                                type: array
-                            type: object
-                          type: array
-                        title:
-                          description: The title of the alert enrichment.
-                          type: string
-                      type: object
-                    type: array
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            explain:
+                              description: Generate AI explanation and store in an
+                                annotation.
+                              properties:
+                                annotation:
+                                  description: Annotation name to set the explanation
+                                    in. Defaults to 'ai_explanation'.
+                                  type: string
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                            external:
+                              description: Call an external HTTP service for enrichment.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                                url:
+                                  description: HTTP endpoint URL to call for enrichment
+                                  type: string
+                              type: object
+                            sift:
+                              description: Analyze alerts for patterns and insights.
+                              properties:
+                                timeout:
+                                  description: Maximum execution time (e.g., '30s',
+                                    '1m')
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      title:
+                        description: The title of the alert enrichment.
+                        type: string
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.


### PR DESCRIPTION
AlertEnrichment resources fail to deploy with Crossplane due to incorrect type generation for Terraform's SingleNestedBlock fields. Fields that should be single objects (`metadata`, `spec`, `options`) were generated as arrays, causing errors: `cannot construct dynamic value for TF state: cannot construct tf value from json: AttributeName("metadata"): invalid JSON, expected "{", got "["`.

Added `SingletonListEmbedder` traverser configuration for `grafana_apps_alertenrichment_alertenrichment_v1beta1` to fix this.

Part of https://github.com/grafana/alerting-enricher/issues/73