### PR TITLE
fix: ServiceAccountToken: Do not write partial instance credentials into connection details

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -284,18 +284,18 @@ func Configure(p *ujconfig.Provider) {
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 
-			instanceConfig := map[string]string{}
-			if a, ok := attr["stack_slug"].(string); ok {
-				instanceConfig["url"] = fmt.Sprintf("https://%s.grafana.net", a)
-			} // TODO: set URL from client
-			if a, ok := attr["key"].(string); ok {
-				instanceConfig["auth"] = a
+			stackSlug, hasStackSlugAttribute := attr["stack_slug"].(string)
+			key, hasKeyAttribute := attr["key"].(string)
+			if hasStackSlugAttribute && hasKeyAttribute {
+				instanceConfig := map[string]string{}
+				instanceConfig["url"] = fmt.Sprintf("https://%s.grafana.net", stackSlug)
+				instanceConfig["auth"] = key
+				marshalled, err := json.Marshal(instanceConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["instanceCredentials"] = marshalled
 			}
-			marshalled, err := json.Marshal(instanceConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["instanceCredentials"] = marshalled
 
 			return conn, nil
 		}


### PR DESCRIPTION
This fixes a bug where the serialized json object below they key `instanceCredentials` in the connection secret of a`ServiceAccountToken` looses the `auth` key when the provider is restarted. The proposed change only sets the `instanceCredentials` key if both `auth` and `url` attributes are known.

See #361 for a detailed description of the bug.

### Description of your changes

Fixes #361 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

1. Created a ServiceAccountToken object with a connection secret output 
2. Verified that the connection secret was properly written and contained both `auth` and `url` keys
3. Restarted the provider
4. Verified that the connection secret still contained both attributes


