### PR TITLE
Only update serialized json objects in connection secrets if all attributes are available

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -198,19 +198,17 @@ func Configure(p *ujconfig.Provider) {
 			if a, ok := attr["token"].(string); ok {
 				cloudConfig["cloud_access_policy_token"] = a
 				basicAuthConfig["basicAuthPassword"] = a
+				marshalledBasicAuthConfig, err := json.Marshal(basicAuthConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["basicAuthCredentials"] = marshalledBasicAuthConfig
+				marshalledCloudConfig, err := json.Marshal(cloudConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["cloudCredentials"] = marshalledCloudConfig
 			}
-
-			marshalledBasicAuthConfig, err := json.Marshal(basicAuthConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["basicAuthCredentials"] = marshalledBasicAuthConfig
-
-			marshalledCloudConfig, err := json.Marshal(cloudConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["cloudCredentials"] = marshalledCloudConfig
 			return conn, nil
 		}
 	})
@@ -509,18 +507,18 @@ func Configure(p *ujconfig.Provider) {
 			conn := map[string][]byte{}
 
 			providerConfig := map[string]string{}
-			if a, ok := attr["sm_access_token"].(string); ok {
-				providerConfig["sm_access_token"] = a
-			}
-			if a, ok := attr["stack_sm_api_url"].(string); ok {
-				providerConfig["sm_url"] = a
-			}
-			marshalled, err := json.Marshal(providerConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["smCredentials"] = marshalled
+			stackSmApiUrl, hasStackSmApiUrl := attr["stack_sm_api_url"].(string)
+			smAccessToken, hasSmAccessToken := attr["sm_access_token"].(string)
 
+			if hasStackSmApiUrl && hasSmAccessToken {
+				providerConfig["sm_url"] = stackSmApiUrl
+				providerConfig["sm_access_token"] = smAccessToken
+				marshalled, err := json.Marshal(providerConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["smCredentials"] = marshalled
+			}
 			return conn, nil
 		}
 	})


### PR DESCRIPTION
### Description of your changes

This fixes a bug where the content of connection secrets gets overwritten with an empty object if the provider is restarted. It ensures that serialized json objects in connection secrets in AccessPolicyToken.cloud.grafana.crossplane.io and Installation.sm.grafana.crossplane.io are only updated if all attributes are available.

Fixes #367

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Followed steps-to-reproduce from #367 with an `AccessPolicyToken` object and made sure that the suggested fix solves the issue.

