### PR TITLE
[fix] Remove param for image to not overwrite proper name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,6 @@ jobs:
           namespace: platform-monitoring-cd
           workflow_template: crossplane-provider-grafana
           parameters: |
-            imageName=crossplane/provider-grafana
             dockertag=${{ steps.version.outputs.version }}
             prCommentContext= Triggered by release ${{ steps.version.outputs.version }} in crossplane/crossplane-provider-grafana
             commit_author=grafana-delivery-bot


### PR DESCRIPTION
**Changes in this PR**
- Removes the `imageName` param as it incorrectly overwrites the proper one set [here](https://github.com/grafana/deployment_tools/blob/master/ksonnet/environments/platform-monitoring-cd/deployments/crossplane-provider-grafana.libsonnet#L5)