### PR TITLE
fix(config): Only update instanceCredentials in ServiceAccountToken if  "key" attribute is available

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -329,12 +329,12 @@ func Configure(p *ujconfig.Provider) {
 			// instanceConfig["url"] = fmt.Sprintf("https://%s.grafana.net", a)
 			if a, ok := attr["key"].(string); ok {
 				instanceConfig["auth"] = a
+				marshalled, err := json.Marshal(instanceConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["instanceCredentials"] = marshalled
 			}
-			marshalled, err := json.Marshal(instanceConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["instanceCredentials"] = marshalled
 
 			return conn, nil
 		}


### PR DESCRIPTION
### Description of your changes

This fixes a bug where an empty json object gets written to the key `instanceCredentials` in the connection secret of a `ServiceAccountToken.oss.grafana.crossplane.io` when the provider is restarted. The proposed change only updates the `instanceCredentials` key if the `key` attribute is known.

This PR is a follow-up of #368 ; I forgot to apply the change to `ServiceAccountToken` as well.


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Locally created a `ServiceAccountToken`, then restartet the provider. The version without the fix resets `instanceCredentials` to an empty JSON object. The fixed code does keep the value.

