### PR TITLE
CI: Allow version tags to trigger publish.artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ XPKG_REG_ORGS ?= xpkg.upbound.io/grafana
 # inferred.
 XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/grafana
 XPKGS = $(PROJECT_NAME)
+# Allow version tags (v*) to trigger publish.artifacts
+RELEASE_BRANCH_FILTER := main master release-% v%
 -include build/makelib/xpkg.mk
 
 # ====================================================================================


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When we created a new release yesterday, it wasn't published to the marketplace as expected. We rely on the Crossplane build git submodule for the [publish.artifacts make target](https://github.com/crossplane/build/blob/99c79f0c310d02157495f457f99b95370200c389/makelib/xpkg.mk#L123-L127). It only runs when BRANCH_NAME matches main/master/release-%. Tag pushes set BRANCH_NAME to the tag name (e.g., v1.0.0), which doesn't match, causing a silent no-op. We need to also filter by tag. ([slack](https://raintank-corp.slack.com/archives/C07SUF6SESF/p1768240569038259?thread_ts=1768204470.100349&cid=C07SUF6SESF))

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran `make -n publish BRANCH_NAME=v1.0.0` locally.

[contribution process]: https://git.io/fj2m9
