### PR TITLE
fix(config): Only update instanceCredentials in ServiceAccountToken.oss.grafana.crossplane.io connection secret if the key attribute is available

### DIFF
--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -329,12 +329,12 @@ func Configure(p *ujconfig.Provider) {
 			// instanceConfig["url"] = fmt.Sprintf("https://%s.grafana.net", a)
 			if a, ok := attr["key"].(string); ok {
 				instanceConfig["auth"] = a
+				marshalled, err := json.Marshal(instanceConfig)
+				if err != nil {
+					return nil, err
+				}
+				conn["instanceCredentials"] = marshalled
 			}
-			marshalled, err := json.Marshal(instanceConfig)
-			if err != nil {
-				return nil, err
-			}
-			conn["instanceCredentials"] = marshalled
 
 			return conn, nil
 		}


### PR DESCRIPTION
### Description of your changes

Cherry-pick of the commit in #390 to backport it to 0.40. Fixes #405.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable test`
Since I made no new changes, I did not change the tests.

<details><summary>make reviewable test</summary>
<pre>
:> make reviewable test
11:36:35 [ .. ] generating provider schema for grafana/grafana 4.12.0
11:36:35 [ OK ] generating provider schema for grafana/grafana 4.12.0
11:36:35 [ .. ] go generate linux_amd64

Generated 84 resources!
11:36:41 [ OK ] go generate linux_amd64
11:36:41 [ .. ] go mod tidy
11:36:41 [ OK ] go mod tidy
11:36:42 [ .. ] installing golangci-lint-v1.64.6 linux-amd64
11:36:43 [ OK ] installing golangci-lint-v1.64.6 linux-amd64
11:36:43 [ .. ] golangci-lint
11:37:41 [ OK ] golangci-lint
11:37:41 [ .. ] go test unit-tests
	github.com/grafana/crossplane-provider-grafana/cmd/generator		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/provider		coverage: 0.0% of statements
ok  	github.com/grafana/crossplane-provider-grafana/internal/clients	(cached)	coverage: 67.9% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/alertenrichmentv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/contactpoint		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/messagetemplate		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/mutetiming		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/notificationpolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/rulegroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/custommodelrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/logconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/notificationalertsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/suppressedassertionsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicytoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/appo11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/k8so11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/orgmember		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/plugininstallation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetwork		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetworktoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stack		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awscloudwatchscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsresourcemetadatascrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/azurecredential		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/connections/metricsendpointscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourceconfiglbacrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/report		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/role		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignment		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignmentitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/scimconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/teamexternalgroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/collector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/pipeline		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/frontendobservability/app		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/loadtest		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/project		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectallowedloadzones		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectlimits		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/alertcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/holiday		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/job	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/outlierdetector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalationchain		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/integration		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/oncallshift		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/outgoingwebhook		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/route		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/usernotificationrule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/annotation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboard		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpublic		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasource		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasourceconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folder		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/librarypanel		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organization		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organizationpreferences		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlist		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlistv0alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/ssosettings		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/teamcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/usercoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/providerconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/slo/slo	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkalerts		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/probecoverage: 0.0% of statements
?   	github.com/grafana/crossplane-provider-grafana/internal/features	[no test files]
	github.com/grafana/crossplane-provider-grafana/apis		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/asserts/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloudprovider/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/connections/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/fleetmanagement/v1alpha1coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/frontendobservability/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/k6/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/ml/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oncall/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/slo/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/sm/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/generator		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/provider		coverage: 0.0% of statements
=== RUN   TestTerraformSetupBuilder
=== RUN   TestTerraformSetupBuilder/OrgID_override_takes_precedence_over_credentials
=== RUN   TestTerraformSetupBuilder/StackID_override_takes_precedence_over_credentials
=== RUN   TestTerraformSetupBuilder/OrgID_and_StackID_zero_overrides_are_used
=== RUN   TestTerraformSetupBuilder/Credentials_are_used_when_overrides_are_absent
=== RUN   TestTerraformSetupBuilder/OrgID_and_StackID_omitted_when_not_provided
--- PASS: TestTerraformSetupBuilder (0.02s)
    --- PASS: TestTerraformSetupBuilder/OrgID_override_takes_precedence_over_credentials (0.02s)
    --- PASS: TestTerraformSetupBuilder/StackID_override_takes_precedence_over_credentials (0.00s)
    --- PASS: TestTerraformSetupBuilder/OrgID_and_StackID_zero_overrides_are_used (0.00s)
    --- PASS: TestTerraformSetupBuilder/Credentials_are_used_when_overrides_are_absent (0.00s)
    --- PASS: TestTerraformSetupBuilder/OrgID_and_StackID_omitted_when_not_provided (0.00s)
PASS
coverage: 67.9% of statements
ok  	github.com/grafana/crossplane-provider-grafana/internal/clients	(cached)	coverage: 67.9% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/alertenrichmentv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/contactpoint		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/messagetemplate		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/mutetiming		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/notificationpolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/rulegroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/custommodelrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/logconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/notificationalertsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/suppressedassertionsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicytoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/appo11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/k8so11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/orgmember		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/plugininstallation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetwork		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetworktoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stack		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awscloudwatchscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsresourcemetadatascrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/azurecredential		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/connections/metricsendpointscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourceconfiglbacrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/report		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/role		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignment		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignmentitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/scimconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/teamexternalgroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/collector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/pipeline		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/frontendobservability/app		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/loadtest		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/project		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectallowedloadzones		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectlimits		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/alertcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/holiday		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/job	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/outlierdetector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalationchain		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/integration		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/oncallshift		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/outgoingwebhook		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/route		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/usernotificationrule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/annotation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboard		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpublic		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasource		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasourceconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folder		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/librarypanel		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organization		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organizationpreferences		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlist		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlistv0alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/ssosettings		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/teamcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/usercoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/providerconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/slo/slo	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkalerts		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/probecoverage: 0.0% of statements
?   	github.com/grafana/crossplane-provider-grafana/internal/features	[no test files]
	github.com/grafana/crossplane-provider-grafana/apis		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/asserts/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloudprovider/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/connections/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/fleetmanagement/v1alpha1coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/frontendobservability/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/k6/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/ml/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oncall/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/slo/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/sm/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1beta1		coverage: 0.0% of statements
11:37:48 [ OK ] go test unit-tests
11:37:48 [ .. ] go test unit-tests
	github.com/grafana/crossplane-provider-grafana/cmd/generator		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/provider		coverage: 0.0% of statements
ok  	github.com/grafana/crossplane-provider-grafana/internal/clients	(cached)	coverage: 67.9% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/alertenrichmentv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/contactpoint		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/messagetemplate		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/mutetiming		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/notificationpolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/rulegroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/custommodelrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/logconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/notificationalertsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/suppressedassertionsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicytoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/appo11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/k8so11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/orgmember		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/plugininstallation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetwork		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetworktoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stack		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awscloudwatchscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsresourcemetadatascrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/azurecredential		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/connections/metricsendpointscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourceconfiglbacrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/report		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/role		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignment		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignmentitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/scimconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/teamexternalgroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/collector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/pipeline		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/frontendobservability/app		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/loadtest		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/project		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectallowedloadzones		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectlimits		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/alertcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/holiday		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/job	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/outlierdetector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalationchain		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/integration		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/oncallshift		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/outgoingwebhook		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/route		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/usernotificationrule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/annotation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboard		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpublic		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasource		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasourceconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folder		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/librarypanel		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organization		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organizationpreferences		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlist		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlistv0alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/ssosettings		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/teamcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/usercoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/providerconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/slo/slo	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkalerts		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/probecoverage: 0.0% of statements
?   	github.com/grafana/crossplane-provider-grafana/internal/features	[no test files]
	github.com/grafana/crossplane-provider-grafana/apis		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/asserts/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloudprovider/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/connections/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/fleetmanagement/v1alpha1coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/frontendobservability/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/k6/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/ml/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oncall/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/slo/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/sm/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/generator		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/cmd/provider		coverage: 0.0% of statements
=== RUN   TestTerraformSetupBuilder
=== RUN   TestTerraformSetupBuilder/OrgID_override_takes_precedence_over_credentials
=== RUN   TestTerraformSetupBuilder/StackID_override_takes_precedence_over_credentials
=== RUN   TestTerraformSetupBuilder/OrgID_and_StackID_zero_overrides_are_used
=== RUN   TestTerraformSetupBuilder/Credentials_are_used_when_overrides_are_absent
=== RUN   TestTerraformSetupBuilder/OrgID_and_StackID_omitted_when_not_provided
--- PASS: TestTerraformSetupBuilder (0.02s)
    --- PASS: TestTerraformSetupBuilder/OrgID_override_takes_precedence_over_credentials (0.02s)
    --- PASS: TestTerraformSetupBuilder/StackID_override_takes_precedence_over_credentials (0.00s)
    --- PASS: TestTerraformSetupBuilder/OrgID_and_StackID_zero_overrides_are_used (0.00s)
    --- PASS: TestTerraformSetupBuilder/Credentials_are_used_when_overrides_are_absent (0.00s)
    --- PASS: TestTerraformSetupBuilder/OrgID_and_StackID_omitted_when_not_provided (0.00s)
PASS
coverage: 67.9% of statements
ok  	github.com/grafana/crossplane-provider-grafana/internal/clients	(cached)	coverage: 67.9% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/alertenrichmentv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/contactpoint		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/messagetemplate		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/mutetiming		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/notificationpolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/alerting/rulegroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/custommodelrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/logconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/notificationalertsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/asserts/suppressedassertionsconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicy		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/accesspolicytoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/appo11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/k8so11yconfigv1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/orgmember		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/plugininstallation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetwork		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/privatedatasourceconnectnetworktoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stack		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloud/stackserviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awscloudwatchscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/awsresourcemetadatascrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/cloudprovider/azurecredential		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/connections/metricsendpointscrapejob		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourceconfiglbacrules		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/datasourcepermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/report		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/role		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignment		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/roleassignmentitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/scimconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/enterprise/teamexternalgroup		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/collector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/fleetmanagement/pipeline		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/frontendobservability/app		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/loadtest		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/project		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectallowedloadzones		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/projectlimits		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/k6/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/alertcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/holiday		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/job	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/ml/outlierdetector		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/escalationchain		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/integration		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/oncallshift		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/outgoingwebhook		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/route		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/schedule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oncall/usernotificationrule		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/annotation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboard		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardpublic		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/dashboardv1beta1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasource		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/datasourceconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folder		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/folderpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/librarypanel		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organization		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/organizationpreferences		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlist		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/playlistv0alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccount		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermission		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccountpermissionitem		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/serviceaccounttoken		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/ssosettings		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/teamcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/oss/usercoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/providerconfig		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/slo/slo	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkcoverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/checkalerts		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/installation		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/internal/controller/sm/probecoverage: 0.0% of statements
?   	github.com/grafana/crossplane-provider-grafana/internal/features	[no test files]
	github.com/grafana/crossplane-provider-grafana/apis		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/alerting/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/asserts/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloud/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/cloudprovider/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/connections/v1alpha1	coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/enterprise/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/fleetmanagement/v1alpha1coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/frontendobservability/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/k6/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/ml/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oncall/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/oss/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/slo/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/sm/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1alpha1		coverage: 0.0% of statements
	github.com/grafana/crossplane-provider-grafana/apis/v1beta1		coverage: 0.0% of statements
11:37:54 [ OK ] go test unit-tests
</pre>
</details>

[contribution process]: https://git.io/fj2m9
