### PR TITLE
chore(ci): configure Renovate to run make generate on provider updates

### DIFF
--- a/config/provider.go
+++ b/config/provider.go
@@ -63,11 +63,16 @@ func resourcesByFramework() ([]string, []string) {
 		resourcesMap[r.Name] = true
 	}
 
+	hasMissingFromGroupMap := false
 	for name := range resourcesMap {
 		if _, ok := GroupMap[name]; !ok {
+			hasMissingFromGroupMap = true
 			// list resource not yet included in config/groups.go
 			fmt.Printf("Not in groupMap: %s\n", name)
 		}
+	}
+	if hasMissingFromGroupMap {
+		panic("Some resource are missing from the group map in config/groups.go")
 	}
 
 	var legacySDKResources, pluginFrameworkResources []string

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'config:base',
+    'config:recommended',
   ],
   packageRules: [
     {
@@ -10,6 +10,18 @@
       automerge: true,
       automergeType: 'pr',
       automergeStrategy: 'squash',
+    },
+    {
+      // When terraform-provider-grafana is updated, run make submodules and make generate
+      matchPackageNames: ['github.com/grafana/terraform-provider-grafana/v4'],
+      postUpgradeTasks: {
+        commands: [
+          'make submodules',
+          'make generate',
+        ],
+        fileFilters: ['**/*'],
+        executionMode: 'branch',
+      },
     },
   ],
 }


### PR DESCRIPTION
Fixes #216

Add renovate.json5 to automatically run `make submodules` and `make generate`
when terraform-provider-grafana is updated. Also add validation to panic if
resources are missing from the group map, ensuring generation issues are caught early.

The panic in config/provider.go will make sure the CI fails when new
resources get introduced, this'll require manual intervention.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
