### PR TITLE
fix: update auto-approve workflow to match self-hosted Renovate bot

### DIFF
--- a/.github/workflows/renovate-auto-approve.yaml
+++ b/.github/workflows/renovate-auto-approve.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.type == 'Bot' && github.event.pull_request.user.login == 'renovate[bot]'
+    if: github.event.pull_request.user.type == 'Bot' && github.event.pull_request.user.login == 'renovate-sh-app[bot]'
     steps:
       - name: Check PR labels
         id: check-labels


### PR DESCRIPTION
The auto-approve job was being skipped for all Renovate PRs because the workflow was checking for `renovate[bot]` as the user login, but Grafana's self-hosted Renovate instance uses `renovate-sh-app[bot]` instead.