### PR TITLE
fix: SchemaNestingModeSingle blocks as objects

### DIFF
--- a/apis/cluster/alerting/v1alpha1/zz_alertrulev0alpha1_types.go
+++ b/apis/cluster/alerting/v1alpha1/zz_alertrulev0alpha1_types.go
@@ -16,13 +16,13 @@ import (
 type AlertruleV0Alpha1InitParameters struct {
 
 	// The metadata of the resource.
-	Metadata []AlertruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []AlertruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []AlertruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1MetadataInitParameters struct {
@@ -71,13 +71,13 @@ type AlertruleV0Alpha1Observation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// The metadata of the resource.
-	Metadata []AlertruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []AlertruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []AlertruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1OptionsInitParameters struct {
@@ -103,15 +103,15 @@ type AlertruleV0Alpha1Parameters struct {
 
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []AlertruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []AlertruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []AlertruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecInitParameters struct {
@@ -144,7 +144,7 @@ type AlertruleV0Alpha1SpecInitParameters struct {
 	NoDataState *string `json:"noDataState,omitempty" tf:"no_data_state,omitempty"`
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
-	NotificationSettings []NotificationSettingsInitParameters `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsInitParameters `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +mapType=granular
@@ -157,7 +157,7 @@ type AlertruleV0Alpha1SpecInitParameters struct {
 	Title *string `json:"title,omitempty" tf:"title,omitempty"`
 
 	// The trigger configuration for the alert rule.
-	Trigger []TriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *TriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecObservation struct {
@@ -190,7 +190,7 @@ type AlertruleV0Alpha1SpecObservation struct {
 	NoDataState *string `json:"noDataState,omitempty" tf:"no_data_state,omitempty"`
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
-	NotificationSettings []NotificationSettingsObservation `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsObservation `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +mapType=granular
@@ -203,7 +203,7 @@ type AlertruleV0Alpha1SpecObservation struct {
 	Title *string `json:"title,omitempty" tf:"title,omitempty"`
 
 	// The trigger configuration for the alert rule.
-	Trigger []TriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *TriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecParameters struct {
@@ -245,7 +245,7 @@ type AlertruleV0Alpha1SpecParameters struct {
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
 	// +kubebuilder:validation:Optional
-	NotificationSettings []NotificationSettingsParameters `json:"notificationSettings" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsParameters `json:"notificationSettings" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +kubebuilder:validation:Optional
@@ -262,7 +262,7 @@ type AlertruleV0Alpha1SpecParameters struct {
 
 	// The trigger configuration for the alert rule.
 	// +kubebuilder:validation:Optional
-	Trigger []TriggerParameters `json:"trigger" tf:"trigger,omitempty"`
+	Trigger *TriggerParameters `json:"trigger" tf:"trigger,omitempty"`
 }
 
 type NotificationSettingsInitParameters struct {

--- a/apis/cluster/alerting/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/alerting/v1alpha1/zz_generated.deepcopy.go
@@ -360,24 +360,18 @@ func (in *AlertruleV0Alpha1InitParameters) DeepCopyInto(out *AlertruleV0Alpha1In
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -539,24 +533,18 @@ func (in *AlertruleV0Alpha1Observation) DeepCopyInto(out *AlertruleV0Alpha1Obser
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -635,24 +623,18 @@ func (in *AlertruleV0Alpha1Parameters) DeepCopyInto(out *AlertruleV0Alpha1Parame
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -762,10 +744,8 @@ func (in *AlertruleV0Alpha1SpecInitParameters) DeepCopyInto(out *AlertruleV0Alph
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -795,10 +775,8 @@ func (in *AlertruleV0Alpha1SpecInitParameters) DeepCopyInto(out *AlertruleV0Alph
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -890,10 +868,8 @@ func (in *AlertruleV0Alpha1SpecObservation) DeepCopyInto(out *AlertruleV0Alpha1S
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -923,10 +899,8 @@ func (in *AlertruleV0Alpha1SpecObservation) DeepCopyInto(out *AlertruleV0Alpha1S
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1018,10 +992,8 @@ func (in *AlertruleV0Alpha1SpecParameters) DeepCopyInto(out *AlertruleV0Alpha1Sp
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -1051,10 +1023,8 @@ func (in *AlertruleV0Alpha1SpecParameters) DeepCopyInto(out *AlertruleV0Alpha1Sp
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9711,24 +9681,18 @@ func (in *RecordingruleV0Alpha1InitParameters) DeepCopyInto(out *RecordingruleV0
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9890,24 +9854,18 @@ func (in *RecordingruleV0Alpha1Observation) DeepCopyInto(out *RecordingruleV0Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9986,24 +9944,18 @@ func (in *RecordingruleV0Alpha1Parameters) DeepCopyInto(out *RecordingruleV0Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10092,10 +10044,8 @@ func (in *RecordingruleV0Alpha1SpecInitParameters) DeepCopyInto(out *Recordingru
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10166,10 +10116,8 @@ func (in *RecordingruleV0Alpha1SpecObservation) DeepCopyInto(out *RecordingruleV
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10240,10 +10188,8 @@ func (in *RecordingruleV0Alpha1SpecParameters) DeepCopyInto(out *RecordingruleV0
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/cluster/alerting/v1alpha1/zz_recordingrulev0alpha1_types.go
+++ b/apis/cluster/alerting/v1alpha1/zz_recordingrulev0alpha1_types.go
@@ -17,15 +17,15 @@ type RecordingruleV0Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []RecordingruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []RecordingruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []RecordingruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1MetadataInitParameters struct {
@@ -87,15 +87,15 @@ type RecordingruleV0Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []RecordingruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []RecordingruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []RecordingruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1OptionsInitParameters struct {
@@ -125,17 +125,17 @@ type RecordingruleV0Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []RecordingruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []RecordingruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []RecordingruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecInitParameters struct {
@@ -168,7 +168,7 @@ type RecordingruleV0Alpha1SpecInitParameters struct {
 
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
-	Trigger []SpecTriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecObservation struct {
@@ -201,7 +201,7 @@ type RecordingruleV0Alpha1SpecObservation struct {
 
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
-	Trigger []SpecTriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecParameters struct {
@@ -241,7 +241,7 @@ type RecordingruleV0Alpha1SpecParameters struct {
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
 	// +kubebuilder:validation:Optional
-	Trigger []SpecTriggerParameters `json:"trigger" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerParameters `json:"trigger" tf:"trigger,omitempty"`
 }
 
 type SpecTriggerInitParameters struct {

--- a/apis/cluster/cloud/v1alpha1/zz_appo11yconfigv1alpha1_types.go
+++ b/apis/cluster/cloud/v1alpha1/zz_appo11yconfigv1alpha1_types.go
@@ -17,15 +17,15 @@ type Appo11YconfigV1Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type Appo11YconfigV1Alpha1Observation struct {
@@ -35,15 +35,15 @@ type Appo11YconfigV1Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type Appo11YconfigV1Alpha1Parameters struct {
@@ -51,17 +51,17 @@ type Appo11YconfigV1Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type MetadataInitParameters struct {

--- a/apis/cluster/cloud/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/cloud/v1alpha1/zz_generated.deepcopy.go
@@ -847,24 +847,18 @@ func (in *Appo11YconfigV1Alpha1InitParameters) DeepCopyInto(out *Appo11YconfigV1
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -920,24 +914,18 @@ func (in *Appo11YconfigV1Alpha1Observation) DeepCopyInto(out *Appo11YconfigV1Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -956,24 +944,18 @@ func (in *Appo11YconfigV1Alpha1Parameters) DeepCopyInto(out *Appo11YconfigV1Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1132,24 +1114,18 @@ func (in *K8So11YconfigV1Alpha1InitParameters) DeepCopyInto(out *K8So11YconfigV1
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1311,24 +1287,18 @@ func (in *K8So11YconfigV1Alpha1Observation) DeepCopyInto(out *K8So11YconfigV1Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1407,24 +1377,18 @@ func (in *K8So11YconfigV1Alpha1Parameters) DeepCopyInto(out *K8So11YconfigV1Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/cluster/cloud/v1alpha1/zz_k8so11yconfigv1alpha1_types.go
+++ b/apis/cluster/cloud/v1alpha1/zz_k8so11yconfigv1alpha1_types.go
@@ -17,15 +17,15 @@ type K8So11YconfigV1Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []K8So11YconfigV1Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []K8So11YconfigV1Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []K8So11YconfigV1Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1MetadataInitParameters struct {
@@ -87,15 +87,15 @@ type K8So11YconfigV1Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []K8So11YconfigV1Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []K8So11YconfigV1Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []K8So11YconfigV1Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1OptionsInitParameters struct {
@@ -125,17 +125,17 @@ type K8So11YconfigV1Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []K8So11YconfigV1Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []K8So11YconfigV1Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []K8So11YconfigV1Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1SpecInitParameters struct {

--- a/apis/cluster/k6/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/k6/v1alpha1/zz_generated.deepcopy.go
@@ -1300,10 +1300,8 @@ func (in *ScheduleInitParameters) DeepCopyInto(out *ScheduleInitParameters) {
 	*out = *in
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LoadTestID != nil {
 		in, out := &in.LoadTestID, &out.LoadTestID
@@ -1312,10 +1310,8 @@ func (in *ScheduleInitParameters) DeepCopyInto(out *ScheduleInitParameters) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts
@@ -1376,10 +1372,8 @@ func (in *ScheduleObservation) DeepCopyInto(out *ScheduleObservation) {
 	}
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Deactivated != nil {
 		in, out := &in.Deactivated, &out.Deactivated
@@ -1403,10 +1397,8 @@ func (in *ScheduleObservation) DeepCopyInto(out *ScheduleObservation) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts
@@ -1430,10 +1422,8 @@ func (in *ScheduleParameters) DeepCopyInto(out *ScheduleParameters) {
 	*out = *in
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LoadTestID != nil {
 		in, out := &in.LoadTestID, &out.LoadTestID
@@ -1442,10 +1432,8 @@ func (in *ScheduleParameters) DeepCopyInto(out *ScheduleParameters) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts

--- a/apis/cluster/k6/v1alpha1/zz_schedule_types.go
+++ b/apis/cluster/k6/v1alpha1/zz_schedule_types.go
@@ -126,7 +126,7 @@ type ScheduleInitParameters struct {
 
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	Cron []CronInitParameters `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronInitParameters `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (String) The identifier of the load test to schedule.
 	// The identifier of the load test to schedule.
@@ -134,7 +134,7 @@ type ScheduleInitParameters struct {
 
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	RecurrenceRule []RecurrenceRuleInitParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleInitParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).
@@ -149,7 +149,7 @@ type ScheduleObservation struct {
 
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	Cron []CronObservation `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronObservation `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (Boolean) Whether the schedule is deactivated.
 	// Whether the schedule is deactivated.
@@ -168,7 +168,7 @@ type ScheduleObservation struct {
 
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	RecurrenceRule []RecurrenceRuleObservation `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleObservation `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).
@@ -180,7 +180,7 @@ type ScheduleParameters struct {
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
 	// +kubebuilder:validation:Optional
-	Cron []CronParameters `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronParameters `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (String) The identifier of the load test to schedule.
 	// The identifier of the load test to schedule.
@@ -190,7 +190,7 @@ type ScheduleParameters struct {
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
 	// +kubebuilder:validation:Optional
-	RecurrenceRule []RecurrenceRuleParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).

--- a/apis/cluster/oss/v1alpha1/zz_dashboardv1beta1_types.go
+++ b/apis/cluster/oss/v1alpha1/zz_dashboardv1beta1_types.go
@@ -17,15 +17,15 @@ type DashboardV1Beta1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type DashboardV1Beta1Observation struct {
@@ -35,15 +35,15 @@ type DashboardV1Beta1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type DashboardV1Beta1Parameters struct {
@@ -51,17 +51,17 @@ type DashboardV1Beta1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type MetadataInitParameters struct {

--- a/apis/cluster/oss/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/oss/v1alpha1/zz_generated.deepcopy.go
@@ -1490,24 +1490,18 @@ func (in *DashboardV1Beta1InitParameters) DeepCopyInto(out *DashboardV1Beta1Init
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1563,24 +1557,18 @@ func (in *DashboardV1Beta1Observation) DeepCopyInto(out *DashboardV1Beta1Observa
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1599,24 +1587,18 @@ func (in *DashboardV1Beta1Parameters) DeepCopyInto(out *DashboardV1Beta1Paramete
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5710,24 +5692,18 @@ func (in *PlaylistV0Alpha1InitParameters) DeepCopyInto(out *PlaylistV0Alpha1Init
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5889,24 +5865,18 @@ func (in *PlaylistV0Alpha1Observation) DeepCopyInto(out *PlaylistV0Alpha1Observa
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5985,24 +5955,18 @@ func (in *PlaylistV0Alpha1Parameters) DeepCopyInto(out *PlaylistV0Alpha1Paramete
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/cluster/oss/v1alpha1/zz_playlistv0alpha1_types.go
+++ b/apis/cluster/oss/v1alpha1/zz_playlistv0alpha1_types.go
@@ -46,15 +46,15 @@ type PlaylistV0Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []PlaylistV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []PlaylistV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []PlaylistV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1MetadataInitParameters struct {
@@ -116,15 +116,15 @@ type PlaylistV0Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []PlaylistV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []PlaylistV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []PlaylistV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1OptionsInitParameters struct {
@@ -154,17 +154,17 @@ type PlaylistV0Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []PlaylistV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []PlaylistV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []PlaylistV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1SpecInitParameters struct {

--- a/apis/namespaced/alerting/v1alpha1/zz_alertrulev0alpha1_types.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_alertrulev0alpha1_types.go
@@ -17,13 +17,13 @@ import (
 type AlertruleV0Alpha1InitParameters struct {
 
 	// The metadata of the resource.
-	Metadata []AlertruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []AlertruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []AlertruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1MetadataInitParameters struct {
@@ -72,13 +72,13 @@ type AlertruleV0Alpha1Observation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// The metadata of the resource.
-	Metadata []AlertruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
-	Options []AlertruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
-	Spec []AlertruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1OptionsInitParameters struct {
@@ -104,15 +104,15 @@ type AlertruleV0Alpha1Parameters struct {
 
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []AlertruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *AlertruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []AlertruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *AlertruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []AlertruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *AlertruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecInitParameters struct {
@@ -145,7 +145,7 @@ type AlertruleV0Alpha1SpecInitParameters struct {
 	NoDataState *string `json:"noDataState,omitempty" tf:"no_data_state,omitempty"`
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
-	NotificationSettings []NotificationSettingsInitParameters `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsInitParameters `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +mapType=granular
@@ -158,7 +158,7 @@ type AlertruleV0Alpha1SpecInitParameters struct {
 	Title *string `json:"title,omitempty" tf:"title,omitempty"`
 
 	// The trigger configuration for the alert rule.
-	Trigger []TriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *TriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecObservation struct {
@@ -191,7 +191,7 @@ type AlertruleV0Alpha1SpecObservation struct {
 	NoDataState *string `json:"noDataState,omitempty" tf:"no_data_state,omitempty"`
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
-	NotificationSettings []NotificationSettingsObservation `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsObservation `json:"notificationSettings,omitempty" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +mapType=granular
@@ -204,7 +204,7 @@ type AlertruleV0Alpha1SpecObservation struct {
 	Title *string `json:"title,omitempty" tf:"title,omitempty"`
 
 	// The trigger configuration for the alert rule.
-	Trigger []TriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *TriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type AlertruleV0Alpha1SpecParameters struct {
@@ -246,7 +246,7 @@ type AlertruleV0Alpha1SpecParameters struct {
 
 	// Notification settings for the rule. If specified, it overrides the notification policies.
 	// +kubebuilder:validation:Optional
-	NotificationSettings []NotificationSettingsParameters `json:"notificationSettings" tf:"notification_settings,omitempty"`
+	NotificationSettings *NotificationSettingsParameters `json:"notificationSettings" tf:"notification_settings,omitempty"`
 
 	// Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 	// +kubebuilder:validation:Optional
@@ -263,7 +263,7 @@ type AlertruleV0Alpha1SpecParameters struct {
 
 	// The trigger configuration for the alert rule.
 	// +kubebuilder:validation:Optional
-	Trigger []TriggerParameters `json:"trigger" tf:"trigger,omitempty"`
+	Trigger *TriggerParameters `json:"trigger" tf:"trigger,omitempty"`
 }
 
 type NotificationSettingsInitParameters struct {

--- a/apis/namespaced/alerting/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_generated.deepcopy.go
@@ -360,24 +360,18 @@ func (in *AlertruleV0Alpha1InitParameters) DeepCopyInto(out *AlertruleV0Alpha1In
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -539,24 +533,18 @@ func (in *AlertruleV0Alpha1Observation) DeepCopyInto(out *AlertruleV0Alpha1Obser
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -635,24 +623,18 @@ func (in *AlertruleV0Alpha1Parameters) DeepCopyInto(out *AlertruleV0Alpha1Parame
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]AlertruleV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]AlertruleV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]AlertruleV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(AlertruleV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -762,10 +744,8 @@ func (in *AlertruleV0Alpha1SpecInitParameters) DeepCopyInto(out *AlertruleV0Alph
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -795,10 +775,8 @@ func (in *AlertruleV0Alpha1SpecInitParameters) DeepCopyInto(out *AlertruleV0Alph
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -890,10 +868,8 @@ func (in *AlertruleV0Alpha1SpecObservation) DeepCopyInto(out *AlertruleV0Alpha1S
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -923,10 +899,8 @@ func (in *AlertruleV0Alpha1SpecObservation) DeepCopyInto(out *AlertruleV0Alpha1S
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1018,10 +992,8 @@ func (in *AlertruleV0Alpha1SpecParameters) DeepCopyInto(out *AlertruleV0Alpha1Sp
 	}
 	if in.NotificationSettings != nil {
 		in, out := &in.NotificationSettings, &out.NotificationSettings
-		*out = make([]NotificationSettingsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(NotificationSettingsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PanelRef != nil {
 		in, out := &in.PanelRef, &out.PanelRef
@@ -1051,10 +1023,8 @@ func (in *AlertruleV0Alpha1SpecParameters) DeepCopyInto(out *AlertruleV0Alpha1Sp
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]TriggerParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(TriggerParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9711,24 +9681,18 @@ func (in *RecordingruleV0Alpha1InitParameters) DeepCopyInto(out *RecordingruleV0
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9890,24 +9854,18 @@ func (in *RecordingruleV0Alpha1Observation) DeepCopyInto(out *RecordingruleV0Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -9986,24 +9944,18 @@ func (in *RecordingruleV0Alpha1Parameters) DeepCopyInto(out *RecordingruleV0Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]RecordingruleV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]RecordingruleV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]RecordingruleV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecordingruleV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10092,10 +10044,8 @@ func (in *RecordingruleV0Alpha1SpecInitParameters) DeepCopyInto(out *Recordingru
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10166,10 +10116,8 @@ func (in *RecordingruleV0Alpha1SpecObservation) DeepCopyInto(out *RecordingruleV
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -10240,10 +10188,8 @@ func (in *RecordingruleV0Alpha1SpecParameters) DeepCopyInto(out *RecordingruleV0
 	}
 	if in.Trigger != nil {
 		in, out := &in.Trigger, &out.Trigger
-		*out = make([]SpecTriggerParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecTriggerParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/namespaced/alerting/v1alpha1/zz_recordingrulev0alpha1_types.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_recordingrulev0alpha1_types.go
@@ -18,15 +18,15 @@ type RecordingruleV0Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []RecordingruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []RecordingruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []RecordingruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1MetadataInitParameters struct {
@@ -88,15 +88,15 @@ type RecordingruleV0Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []RecordingruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []RecordingruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []RecordingruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1OptionsInitParameters struct {
@@ -126,17 +126,17 @@ type RecordingruleV0Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []RecordingruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *RecordingruleV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []RecordingruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *RecordingruleV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []RecordingruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *RecordingruleV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecInitParameters struct {
@@ -169,7 +169,7 @@ type RecordingruleV0Alpha1SpecInitParameters struct {
 
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
-	Trigger []SpecTriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerInitParameters `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecObservation struct {
@@ -202,7 +202,7 @@ type RecordingruleV0Alpha1SpecObservation struct {
 
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
-	Trigger []SpecTriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerObservation `json:"trigger,omitempty" tf:"trigger,omitempty"`
 }
 
 type RecordingruleV0Alpha1SpecParameters struct {
@@ -242,7 +242,7 @@ type RecordingruleV0Alpha1SpecParameters struct {
 	// (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
 	// The trigger configuration for the recording rule.
 	// +kubebuilder:validation:Optional
-	Trigger []SpecTriggerParameters `json:"trigger" tf:"trigger,omitempty"`
+	Trigger *SpecTriggerParameters `json:"trigger" tf:"trigger,omitempty"`
 }
 
 type SpecTriggerInitParameters struct {

--- a/apis/namespaced/cloud/v1alpha1/zz_appo11yconfigv1alpha1_types.go
+++ b/apis/namespaced/cloud/v1alpha1/zz_appo11yconfigv1alpha1_types.go
@@ -18,15 +18,15 @@ type Appo11YconfigV1Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type Appo11YconfigV1Alpha1Observation struct {
@@ -36,15 +36,15 @@ type Appo11YconfigV1Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type Appo11YconfigV1Alpha1Parameters struct {
@@ -52,17 +52,17 @@ type Appo11YconfigV1Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type MetadataInitParameters struct {

--- a/apis/namespaced/cloud/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/cloud/v1alpha1/zz_generated.deepcopy.go
@@ -847,24 +847,18 @@ func (in *Appo11YconfigV1Alpha1InitParameters) DeepCopyInto(out *Appo11YconfigV1
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -920,24 +914,18 @@ func (in *Appo11YconfigV1Alpha1Observation) DeepCopyInto(out *Appo11YconfigV1Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -956,24 +944,18 @@ func (in *Appo11YconfigV1Alpha1Parameters) DeepCopyInto(out *Appo11YconfigV1Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1132,24 +1114,18 @@ func (in *K8So11YconfigV1Alpha1InitParameters) DeepCopyInto(out *K8So11YconfigV1
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1311,24 +1287,18 @@ func (in *K8So11YconfigV1Alpha1Observation) DeepCopyInto(out *K8So11YconfigV1Alp
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1407,24 +1377,18 @@ func (in *K8So11YconfigV1Alpha1Parameters) DeepCopyInto(out *K8So11YconfigV1Alph
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]K8So11YconfigV1Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]K8So11YconfigV1Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]K8So11YconfigV1Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(K8So11YconfigV1Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/namespaced/cloud/v1alpha1/zz_k8so11yconfigv1alpha1_types.go
+++ b/apis/namespaced/cloud/v1alpha1/zz_k8so11yconfigv1alpha1_types.go
@@ -18,15 +18,15 @@ type K8So11YconfigV1Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []K8So11YconfigV1Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []K8So11YconfigV1Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []K8So11YconfigV1Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1MetadataInitParameters struct {
@@ -88,15 +88,15 @@ type K8So11YconfigV1Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []K8So11YconfigV1Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []K8So11YconfigV1Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []K8So11YconfigV1Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1OptionsInitParameters struct {
@@ -126,17 +126,17 @@ type K8So11YconfigV1Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []K8So11YconfigV1Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *K8So11YconfigV1Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []K8So11YconfigV1Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *K8So11YconfigV1Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []K8So11YconfigV1Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *K8So11YconfigV1Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type K8So11YconfigV1Alpha1SpecInitParameters struct {

--- a/apis/namespaced/k6/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/k6/v1alpha1/zz_generated.deepcopy.go
@@ -1300,10 +1300,8 @@ func (in *ScheduleInitParameters) DeepCopyInto(out *ScheduleInitParameters) {
 	*out = *in
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LoadTestID != nil {
 		in, out := &in.LoadTestID, &out.LoadTestID
@@ -1312,10 +1310,8 @@ func (in *ScheduleInitParameters) DeepCopyInto(out *ScheduleInitParameters) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts
@@ -1376,10 +1372,8 @@ func (in *ScheduleObservation) DeepCopyInto(out *ScheduleObservation) {
 	}
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Deactivated != nil {
 		in, out := &in.Deactivated, &out.Deactivated
@@ -1403,10 +1397,8 @@ func (in *ScheduleObservation) DeepCopyInto(out *ScheduleObservation) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts
@@ -1430,10 +1422,8 @@ func (in *ScheduleParameters) DeepCopyInto(out *ScheduleParameters) {
 	*out = *in
 	if in.Cron != nil {
 		in, out := &in.Cron, &out.Cron
-		*out = make([]CronParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(CronParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LoadTestID != nil {
 		in, out := &in.LoadTestID, &out.LoadTestID
@@ -1442,10 +1432,8 @@ func (in *ScheduleParameters) DeepCopyInto(out *ScheduleParameters) {
 	}
 	if in.RecurrenceRule != nil {
 		in, out := &in.RecurrenceRule, &out.RecurrenceRule
-		*out = make([]RecurrenceRuleParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(RecurrenceRuleParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Starts != nil {
 		in, out := &in.Starts, &out.Starts

--- a/apis/namespaced/k6/v1alpha1/zz_schedule_types.go
+++ b/apis/namespaced/k6/v1alpha1/zz_schedule_types.go
@@ -127,7 +127,7 @@ type ScheduleInitParameters struct {
 
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	Cron []CronInitParameters `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronInitParameters `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (String) The identifier of the load test to schedule.
 	// The identifier of the load test to schedule.
@@ -135,7 +135,7 @@ type ScheduleInitParameters struct {
 
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	RecurrenceRule []RecurrenceRuleInitParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleInitParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).
@@ -150,7 +150,7 @@ type ScheduleObservation struct {
 
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	Cron []CronObservation `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronObservation `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (Boolean) Whether the schedule is deactivated.
 	// Whether the schedule is deactivated.
@@ -169,7 +169,7 @@ type ScheduleObservation struct {
 
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-	RecurrenceRule []RecurrenceRuleObservation `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleObservation `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).
@@ -181,7 +181,7 @@ type ScheduleParameters struct {
 	// (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
 	// +kubebuilder:validation:Optional
-	Cron []CronParameters `json:"cron,omitempty" tf:"cron,omitempty"`
+	Cron *CronParameters `json:"cron,omitempty" tf:"cron,omitempty"`
 
 	// (String) The identifier of the load test to schedule.
 	// The identifier of the load test to schedule.
@@ -191,7 +191,7 @@ type ScheduleParameters struct {
 	// (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
 	// The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
 	// +kubebuilder:validation:Optional
-	RecurrenceRule []RecurrenceRuleParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
+	RecurrenceRule *RecurrenceRuleParameters `json:"recurrenceRule,omitempty" tf:"recurrence_rule,omitempty"`
 
 	// (String) The start time for the schedule (RFC3339 format).
 	// The start time for the schedule (RFC3339 format).

--- a/apis/namespaced/oss/v1alpha1/zz_dashboardv1beta1_types.go
+++ b/apis/namespaced/oss/v1alpha1/zz_dashboardv1beta1_types.go
@@ -18,15 +18,15 @@ type DashboardV1Beta1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type DashboardV1Beta1Observation struct {
@@ -36,15 +36,15 @@ type DashboardV1Beta1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type DashboardV1Beta1Parameters struct {
@@ -52,17 +52,17 @@ type DashboardV1Beta1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type MetadataInitParameters struct {

--- a/apis/namespaced/oss/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/oss/v1alpha1/zz_generated.deepcopy.go
@@ -1490,24 +1490,18 @@ func (in *DashboardV1Beta1InitParameters) DeepCopyInto(out *DashboardV1Beta1Init
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1563,24 +1557,18 @@ func (in *DashboardV1Beta1Observation) DeepCopyInto(out *DashboardV1Beta1Observa
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1599,24 +1587,18 @@ func (in *DashboardV1Beta1Parameters) DeepCopyInto(out *DashboardV1Beta1Paramete
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5710,24 +5692,18 @@ func (in *PlaylistV0Alpha1InitParameters) DeepCopyInto(out *PlaylistV0Alpha1Init
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecInitParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecInitParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5889,24 +5865,18 @@ func (in *PlaylistV0Alpha1Observation) DeepCopyInto(out *PlaylistV0Alpha1Observa
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsObservation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecObservation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecObservation)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -5985,24 +5955,18 @@ func (in *PlaylistV0Alpha1Parameters) DeepCopyInto(out *PlaylistV0Alpha1Paramete
 	*out = *in
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
-		*out = make([]PlaylistV0Alpha1MetadataParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1MetadataParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make([]PlaylistV0Alpha1OptionsParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1OptionsParameters)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
-		*out = make([]PlaylistV0Alpha1SpecParameters, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = new(PlaylistV0Alpha1SpecParameters)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/apis/namespaced/oss/v1alpha1/zz_playlistv0alpha1_types.go
+++ b/apis/namespaced/oss/v1alpha1/zz_playlistv0alpha1_types.go
@@ -47,15 +47,15 @@ type PlaylistV0Alpha1InitParameters struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []PlaylistV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataInitParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []PlaylistV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsInitParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []PlaylistV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecInitParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1MetadataInitParameters struct {
@@ -117,15 +117,15 @@ type PlaylistV0Alpha1Observation struct {
 
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
-	Metadata []PlaylistV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataObservation `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
-	Options []PlaylistV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsObservation `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
-	Spec []PlaylistV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecObservation `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1OptionsInitParameters struct {
@@ -155,17 +155,17 @@ type PlaylistV0Alpha1Parameters struct {
 	// (Block, Optional) The metadata of the resource. (see below for nested schema)
 	// The metadata of the resource.
 	// +kubebuilder:validation:Optional
-	Metadata []PlaylistV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
+	Metadata *PlaylistV0Alpha1MetadataParameters `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// (Block, Optional) Options for applying the resource. (see below for nested schema)
 	// Options for applying the resource.
 	// +kubebuilder:validation:Optional
-	Options []PlaylistV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
+	Options *PlaylistV0Alpha1OptionsParameters `json:"options,omitempty" tf:"options,omitempty"`
 
 	// (Block, Optional) The spec of the resource. (see below for nested schema)
 	// The spec of the resource.
 	// +kubebuilder:validation:Optional
-	Spec []PlaylistV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
+	Spec *PlaylistV0Alpha1SpecParameters `json:"spec,omitempty" tf:"spec,omitempty"`
 }
 
 type PlaylistV0Alpha1SpecInitParameters struct {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.1.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
-	github.com/crossplane/upjet/v2 v2.1.0
+	github.com/crossplane/upjet/v2 v2.2.0
 	github.com/google/go-cmp v0.7.0
 	github.com/grafana/terraform-provider-grafana/v4 v4.25.0
 	github.com/hashicorp/terraform-json v0.27.2
@@ -242,4 +242,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/crossplane/upjet/v2 => github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18
+replace github.com/crossplane/upjet/v2 => github.com/grafana/upjet/v2 v2.0.0-20260213085820-76c0da58c1b9

--- a/go.mod
+++ b/go.mod
@@ -242,4 +242,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/crossplane/upjet/v2 => github.com/rwwiv/upjet/v2 v2.1.1-0.20260130154016-5bea6888b4c8
+replace github.com/crossplane/upjet/v2 => github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 h1:6ZQoQVD0sASxe5O
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1/go.mod h1:3XfDhlxYkC/Apaug0e0vd4wHx8JZJ4k+v5ybny8ZGfc=
 github.com/grafana/terraform-provider-grafana/v4 v4.25.0 h1:1V+H4ILdtPSwdneiet6jjOXAsSanXJC0dLTauW88+w0=
 github.com/grafana/terraform-provider-grafana/v4 v4.25.0/go.mod h1:wtrkN2v6iZ/Rb8LZhGa/8Omm3shtEjUL73E5lx0icHo=
+github.com/grafana/upjet/v2 v2.0.0-20260213085820-76c0da58c1b9 h1:Pxh+hnc5vuZWnoh5M2GkBJ3OWo9tR985JHDtOfqbdgs=
+github.com/grafana/upjet/v2 v2.0.0-20260213085820-76c0da58c1b9/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=
@@ -430,8 +432,6 @@ github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18 h1:Q5qGBm7ALvhmeEqBVWbT1zqfTtLQb9Ms5OWKdWrX7A4=
-github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/rwwiv/upjet/v2 v2.1.1-0.20260130154016-5bea6888b4c8 h1:Ctl2NUi14lFv3h+jVdvDNz404+aVzWIH3rP34gmkY+Y=
-github.com/rwwiv/upjet/v2 v2.1.1-0.20260130154016-5bea6888b4c8/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
+github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18 h1:Q5qGBm7ALvhmeEqBVWbT1zqfTtLQb9Ms5OWKdWrX7A4=
+github.com/rwwiv/upjet/v2 v2.1.1-0.20260212210120-fb6b3fa90d18/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/package/crds/alerting.grafana.crossplane.io_alertrulev0alpha1s.yaml
+++ b/package/crds/alerting.grafana.crossplane.io_alertrulev0alpha1s.yaml
@@ -75,150 +75,138 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -235,150 +223,138 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -484,166 +460,154 @@ spec:
                     type: string
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: The globally unique identifier of a resource,
-                            used by the API for tracking.
-                          type: string
-                        version:
-                          description: The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: The globally unique identifier of a resource,
+                          used by the API for tracking.
+                        type: string
+                      version:
+                        description: The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/alerting.grafana.crossplane.io_recordingrulev0alpha1s.yaml
+++ b/package/crds/alerting.grafana.crossplane.io_recordingrulev0alpha1s.yaml
@@ -77,90 +77,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -179,90 +171,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -372,113 +356,105 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/alerting.grafana.m.crossplane.io_alertrulev0alpha1s.yaml
+++ b/package/crds/alerting.grafana.m.crossplane.io_alertrulev0alpha1s.yaml
@@ -61,150 +61,138 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -221,150 +209,138 @@ spec:
                 properties:
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
-                          type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -442,166 +418,154 @@ spec:
                     type: string
                   metadata:
                     description: The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: The UID of the folder to save the resource
-                            in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: The globally unique identifier of a resource,
-                            used by the API for tracking.
-                          type: string
-                        version:
-                          description: The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: The globally unique identifier of a resource,
+                          used by the API for tracking.
+                        type: string
+                      version:
+                        description: The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: Set to true if you want to overwrite existing
-                            resource with newer version, same resource title in folder
-                            or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: Set to true if you want to overwrite existing
+                          resource with newer version, same resource title in folder
+                          or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: The spec of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs of metadata to attach to the
+                          alert rule. They add additional information, such as a `summary`
+                          or `runbook_url`, to help identify and investigate alerts.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      execErrState:
+                        description: Describes what state to enter when the rule's
+                          query is invalid and the rule cannot be executed. Options
+                          are OK, Error, KeepLast, and Alerting.
+                        type: string
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: A sequence of stages that describe the contents
+                          of the rule. Each value is a JSON string representing an
+                          expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      for:
+                        description: The amount of time for which the rule must be
+                          breached for the rule to be considered to be Firing. Before
+                          this time has elapsed, the rule is only considered to be
+                          Pending.
+                        type: string
+                      keepFiringFor:
+                        description: The amount of time for which the rule will considered
+                          to be Recovering after initially Firing. Before this time
+                          has elapsed, the rule will continue to fire once it's been
+                          triggered.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs to attach to the alert rule that
+                          can be used in matching, grouping, and routing.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      missingSeriesEvalsToResolve:
+                        description: The number of missing series evaluations that
+                          must occur before the rule is considered to be resolved.
+                        type: number
+                      noDataState:
+                        description: Describes what state to enter when the rule's
+                          query returns No Data. Options are OK, NoData, KeepLast,
+                          and Alerting.
+                        type: string
+                      notificationSettings:
+                        description: Notification settings for the rule. If specified,
+                          it overrides the notification policies.
+                        properties:
+                          activeTimings:
+                            description: A list of time interval names to apply to
+                              alerts that match this policy to suppress them unless
+                              they are sent at the specified time.
+                            items:
+                              type: string
+                            type: array
+                          contactPoint:
+                            description: The contact point to route notifications
+                              that match this rule to.
                             type: string
-                          description: Key-value pairs of metadata to attach to the
-                            alert rule. They add additional information, such as a
-                            `summary` or `runbook_url`, to help identify and investigate
-                            alerts.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        execErrState:
-                          description: Describes what state to enter when the rule's
-                            query is invalid and the rule cannot be executed. Options
-                            are OK, Error, KeepLast, and Alerting.
-                          type: string
-                        expressions:
-                          additionalProperties:
+                          groupBy:
+                            description: A list of alert labels to group alerts into
+                              notifications by.
+                            items:
+                              type: string
+                            type: array
+                          groupInterval:
+                            description: Minimum time interval between two notifications
+                              for the same group.
                             type: string
-                          description: A sequence of stages that describe the contents
-                            of the rule. Each value is a JSON string representing
-                            an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        for:
-                          description: The amount of time for which the rule must
-                            be breached for the rule to be considered to be Firing.
-                            Before this time has elapsed, the rule is only considered
-                            to be Pending.
-                          type: string
-                        keepFiringFor:
-                          description: The amount of time for which the rule will
-                            considered to be Recovering after initially Firing. Before
-                            this time has elapsed, the rule will continue to fire
-                            once it's been triggered.
-                          type: string
-                        labels:
-                          additionalProperties:
+                          groupWait:
+                            description: Time to wait to buffer alerts of the same
+                              group before sending a notification.
                             type: string
-                          description: Key-value pairs to attach to the alert rule
-                            that can be used in matching, grouping, and routing.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        missingSeriesEvalsToResolve:
-                          description: The number of missing series evaluations that
-                            must occur before the rule is considered to be resolved.
-                          type: number
-                        noDataState:
-                          description: Describes what state to enter when the rule's
-                            query returns No Data. Options are OK, NoData, KeepLast,
-                            and Alerting.
-                          type: string
-                        notificationSettings:
-                          description: Notification settings for the rule. If specified,
-                            it overrides the notification policies.
-                          items:
-                            properties:
-                              activeTimings:
-                                description: A list of time interval names to apply
-                                  to alerts that match this policy to suppress them
-                                  unless they are sent at the specified time.
-                                items:
-                                  type: string
-                                type: array
-                              contactPoint:
-                                description: The contact point to route notifications
-                                  that match this rule to.
-                                type: string
-                              groupBy:
-                                description: A list of alert labels to group alerts
-                                  into notifications by.
-                                items:
-                                  type: string
-                                type: array
-                              groupInterval:
-                                description: Minimum time interval between two notifications
-                                  for the same group.
-                                type: string
-                              groupWait:
-                                description: Time to wait to buffer alerts of the
-                                  same group before sending a notification.
-                                type: string
-                              muteTimings:
-                                description: A list of mute timing names to apply
-                                  to alerts that match this policy.
-                                items:
-                                  type: string
-                                type: array
-                              repeatInterval:
-                                description: Minimum time interval for re-sending
-                                  a notification if an alert is still firing.
-                                type: string
-                            type: object
-                          type: array
-                        panelRef:
-                          additionalProperties:
+                          muteTimings:
+                            description: A list of mute timing names to apply to alerts
+                              that match this policy.
+                            items:
+                              type: string
+                            type: array
+                          repeatInterval:
+                            description: Minimum time interval for re-sending a notification
+                              if an alert is still firing.
                             type: string
-                          description: Reference to a panel that this alert rule is
-                            associated with. Should be an object with 'dashboard_uid'
-                            (string) and 'panel_id' (number) fields.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        paused:
-                          description: Sets whether the rule should be paused or not.
-                          type: boolean
-                        title:
-                          description: The title of the alert rule.
+                        type: object
+                      panelRef:
+                        additionalProperties:
                           type: string
-                        trigger:
-                          description: The trigger configuration for the alert rule.
-                          items:
-                            properties:
-                              interval:
-                                description: The interval at which the alert rule
-                                  should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        description: Reference to a panel that this alert rule is
+                          associated with. Should be an object with 'dashboard_uid'
+                          (string) and 'panel_id' (number) fields.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      paused:
+                        description: Sets whether the rule should be paused or not.
+                        type: boolean
+                      title:
+                        description: The title of the alert rule.
+                        type: string
+                      trigger:
+                        description: The trigger configuration for the alert rule.
+                        properties:
+                          interval:
+                            description: The interval at which the alert rule should
+                              be evaluated.
+                            type: string
+                        type: object
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/alerting.grafana.m.crossplane.io_recordingrulev0alpha1s.yaml
+++ b/package/crds/alerting.grafana.m.crossplane.io_recordingrulev0alpha1s.yaml
@@ -63,90 +63,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -165,90 +157,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -330,113 +314,105 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        expressions:
-                          additionalProperties:
+                    properties:
+                      expressions:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                          A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          value pairs to attach to the recorded metric.
+                          Key-value pairs to attach to the recorded metric.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      metric:
+                        description: |-
+                          (String) The name of the metric to write to.
+                          The name of the metric to write to.
+                        type: string
+                      paused:
+                        description: |-
+                          (Boolean) Sets whether the recording rule should be paused or not.
+                          Sets whether the recording rule should be paused or not.
+                        type: boolean
+                      targetDatasourceUid:
+                        description: |-
+                          (String) The UID of the datasource to write the metric to.
+                          The UID of the datasource to write the metric to.
+                        type: string
+                      title:
+                        description: |-
+                          (String) The title of the recording rule.
+                          The title of the recording rule.
+                        type: string
+                      trigger:
+                        description: |-
+                          (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
+                          The trigger configuration for the recording rule.
+                        properties:
+                          interval:
+                            description: |-
+                              (String) The interval at which the recording rule should be evaluated.
+                              The interval at which the recording rule should be evaluated.
                             type: string
-                          description: |-
-                            (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                            A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            value pairs to attach to the recorded metric.
-                            Key-value pairs to attach to the recorded metric.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        metric:
-                          description: |-
-                            (String) The name of the metric to write to.
-                            The name of the metric to write to.
-                          type: string
-                        paused:
-                          description: |-
-                            (Boolean) Sets whether the recording rule should be paused or not.
-                            Sets whether the recording rule should be paused or not.
-                          type: boolean
-                        targetDatasourceUid:
-                          description: |-
-                            (String) The UID of the datasource to write the metric to.
-                            The UID of the datasource to write the metric to.
-                          type: string
-                        title:
-                          description: |-
-                            (String) The title of the recording rule.
-                            The title of the recording rule.
-                          type: string
-                        trigger:
-                          description: |-
-                            (Block, Optional) The trigger configuration for the recording rule. (see below for nested schema)
-                            The trigger configuration for the recording rule.
-                          items:
-                            properties:
-                              interval:
-                                description: |-
-                                  (String) The interval at which the recording rule should be evaluated.
-                                  The interval at which the recording rule should be evaluated.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                        type: object
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/cloud.grafana.crossplane.io_appo11yconfigv1alpha1s.yaml
+++ b/package/crds/cloud.grafana.crossplane.io_appo11yconfigv1alpha1s.yaml
@@ -80,46 +80,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -138,46 +132,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -287,69 +275,63 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/cloud.grafana.crossplane.io_k8so11yconfigv1alpha1s.yaml
+++ b/package/crds/cloud.grafana.crossplane.io_k8so11yconfigv1alpha1s.yaml
@@ -80,46 +80,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -138,46 +132,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -287,69 +275,63 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/cloud.grafana.m.crossplane.io_appo11yconfigv1alpha1s.yaml
+++ b/package/crds/cloud.grafana.m.crossplane.io_appo11yconfigv1alpha1s.yaml
@@ -66,46 +66,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -124,46 +118,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -245,69 +233,63 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether application observability is enabled.
-                            Whether application observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether application observability is enabled.
+                          Whether application observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/cloud.grafana.m.crossplane.io_k8so11yconfigv1alpha1s.yaml
+++ b/package/crds/cloud.grafana.m.crossplane.io_k8so11yconfigv1alpha1s.yaml
@@ -66,46 +66,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -124,46 +118,40 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -245,69 +233,63 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        enabled:
-                          description: |-
-                            (Boolean) Whether Kubernetes observability is enabled.
-                            Whether Kubernetes observability is enabled.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      enabled:
+                        description: |-
+                          (Boolean) Whether Kubernetes observability is enabled.
+                          Whether Kubernetes observability is enabled.
+                        type: boolean
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/k6.grafana.crossplane.io_schedules.yaml
+++ b/package/crds/k6.grafana.crossplane.io_schedules.yaml
@@ -77,20 +77,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   loadTestId:
                     description: |-
                       (String) The identifier of the load test to schedule.
@@ -100,37 +98,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).
@@ -154,20 +150,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   loadTestId:
                     description: |-
                       (String) The identifier of the load test to schedule.
@@ -177,37 +171,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).
@@ -323,20 +315,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   deactivated:
                     description: |-
                       (Boolean) Whether the schedule is deactivated.
@@ -359,37 +349,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).

--- a/package/crds/k6.grafana.m.crossplane.io_schedules.yaml
+++ b/package/crds/k6.grafana.m.crossplane.io_schedules.yaml
@@ -63,20 +63,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   loadTestId:
                     description: |-
                       (String) The identifier of the load test to schedule.
@@ -86,37 +84,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).
@@ -140,20 +136,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   loadTestId:
                     description: |-
                       (String) The identifier of the load test to schedule.
@@ -163,37 +157,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).
@@ -281,20 +273,18 @@ spec:
                     description: |-
                       (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        schedule:
-                          description: |-
-                            (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-                            A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-                          type: string
-                        timezone:
-                          description: |-
-                            (String) The timezone of the cron expression. For example, UTC or Europe/London.
-                            The timezone of the cron expression. For example, `UTC` or `Europe/London`.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      schedule:
+                        description: |-
+                          (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+                          A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+                        type: string
+                      timezone:
+                        description: |-
+                          (String) The timezone of the cron expression. For example, UTC or Europe/London.
+                          The timezone of the cron expression. For example, `UTC` or `Europe/London`.
+                        type: string
+                    type: object
                   deactivated:
                     description: |-
                       (Boolean) Whether the schedule is deactivated.
@@ -317,37 +307,35 @@ spec:
                     description: |-
                       (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of recurrence_rule and cron can be set. (see below for nested schema)
                       The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.
-                    items:
-                      properties:
-                        byday:
-                          description: |-
-                            (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                            The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
-                          items:
-                            type: string
-                          type: array
-                        count:
-                          description: |-
-                            (Number) How many times the recurrence will repeat.
-                            How many times the recurrence will repeat.
-                          type: number
-                        frequency:
-                          description: |-
-                            (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
-                            The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                    properties:
+                      byday:
+                        description: |-
+                          (List of String) The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                          The weekdays when the 'WEEKLY' recurrence will be applied (e.g., ['MO', 'WE', 'FR']). Cannot be set for other frequencies.
+                        items:
                           type: string
-                        interval:
-                          description: |-
-                            (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                            The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
-                          type: number
-                        until:
-                          description: |-
-                            (String) The end time for the recurrence (RFC3339 format).
-                            The end time for the recurrence (RFC3339 format).
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      count:
+                        description: |-
+                          (Number) How many times the recurrence will repeat.
+                          How many times the recurrence will repeat.
+                        type: number
+                      frequency:
+                        description: |-
+                          (String) The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                          The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).
+                        type: string
+                      interval:
+                        description: |-
+                          (Number) The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                          The interval between each frequency iteration (e.g., 2 = every 2 hours for HOURLY). Defaults to 1.
+                        type: number
+                      until:
+                        description: |-
+                          (String) The end time for the recurrence (RFC3339 format).
+                          The end time for the recurrence (RFC3339 format).
+                        type: string
+                    type: object
                   starts:
                     description: |-
                       (String) The start time for the schedule (RFC3339 format).

--- a/package/crds/oss.grafana.crossplane.io_dashboardv1beta1s.yaml
+++ b/package/crds/oss.grafana.crossplane.io_dashboardv1beta1s.yaml
@@ -78,58 +78,52 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -148,58 +142,52 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -308,81 +296,75 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/oss.grafana.crossplane.io_playlistv0alpha1s.yaml
+++ b/package/crds/oss.grafana.crossplane.io_playlistv0alpha1s.yaml
@@ -79,65 +79,59 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -156,65 +150,59 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -323,88 +311,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/oss.grafana.m.crossplane.io_dashboardv1beta1s.yaml
+++ b/package/crds/oss.grafana.m.crossplane.io_dashboardv1beta1s.yaml
@@ -64,58 +64,52 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -134,58 +128,52 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -266,81 +254,75 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        json:
-                          description: |-
-                            (String) The JSON representation of the dashboard spec.
-                            The JSON representation of the dashboard spec.
+                    properties:
+                      json:
+                        description: |-
+                          (String) The JSON representation of the dashboard spec.
+                          The JSON representation of the dashboard spec.
+                        type: string
+                      tags:
+                        description: |-
+                          (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                          The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
+                        items:
                           type: string
-                        tags:
-                          description: |-
-                            (List of String) The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                            The tags of the dashboard. If not set, the tags will be derived from the JSON spec.
-                          items:
-                            type: string
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                            The title of the dashboard. If not set, the title will be derived from the JSON spec.
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                          The title of the dashboard. If not set, the title will be derived from the JSON spec.
+                        type: string
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/oss.grafana.m.crossplane.io_playlistv0alpha1s.yaml
+++ b/package/crds/oss.grafana.m.crossplane.io_playlistv0alpha1s.yaml
@@ -65,65 +65,59 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               initProvider:
                 description: |-
@@ -142,65 +136,59 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
-                          type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                      type: object
-                    type: array
+                    properties:
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -281,88 +269,82 @@ spec:
                     description: |-
                       (Block, Optional) The metadata of the resource. (see below for nested schema)
                       The metadata of the resource.
-                    items:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            (Map of String) Annotations of the resource.
-                            Annotations of the resource.
-                          type: object
-                          x-kubernetes-map-type: granular
-                        folderUid:
-                          description: |-
-                            (String) The UID of the folder to save the resource in.
-                            The UID of the folder to save the resource in.
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        uid:
-                          description: |-
-                            (String) The unique identifier of the resource.
-                            The unique identifier of the resource.
-                          type: string
-                        url:
-                          description: |-
-                            (String) The full URL of the resource.
-                            The full URL of the resource.
-                          type: string
-                        uuid:
-                          description: |-
-                            (String) The globally unique identifier of a resource, used by the API for tracking.
-                            The globally unique identifier of a resource, used by the API for tracking.
-                          type: string
-                        version:
-                          description: |-
-                            (String) The version of the resource.
-                            The version of the resource.
-                          type: string
-                      type: object
-                    type: array
+                        description: |-
+                          (Map of String) Annotations of the resource.
+                          Annotations of the resource.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      folderUid:
+                        description: |-
+                          (String) The UID of the folder to save the resource in.
+                          The UID of the folder to save the resource in.
+                        type: string
+                      uid:
+                        description: |-
+                          (String) The unique identifier of the resource.
+                          The unique identifier of the resource.
+                        type: string
+                      url:
+                        description: |-
+                          (String) The full URL of the resource.
+                          The full URL of the resource.
+                        type: string
+                      uuid:
+                        description: |-
+                          (String) The globally unique identifier of a resource, used by the API for tracking.
+                          The globally unique identifier of a resource, used by the API for tracking.
+                        type: string
+                      version:
+                        description: |-
+                          (String) The version of the resource.
+                          The version of the resource.
+                        type: string
+                    type: object
                   options:
                     description: |-
                       (Block, Optional) Options for applying the resource. (see below for nested schema)
                       Options for applying the resource.
-                    items:
-                      properties:
-                        overwrite:
-                          description: |-
-                            (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                            Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
-                          type: boolean
-                      type: object
-                    type: array
+                    properties:
+                      overwrite:
+                        description: |-
+                          (Boolean) Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                          Set to true if you want to overwrite existing resource with newer version, same resource title in folder or same resource uid.
+                        type: boolean
+                    type: object
                   spec:
                     description: |-
                       (Block, Optional) The spec of the resource. (see below for nested schema)
                       The spec of the resource.
-                    items:
-                      properties:
-                        interval:
-                          description: |-
-                            (String) The interval of the playlist.
-                            The interval of the playlist.
-                          type: string
+                    properties:
+                      interval:
+                        description: |-
+                          (String) The interval of the playlist.
+                          The interval of the playlist.
+                        type: string
+                      items:
+                        description: |-
+                          (List of Object) The items of the playlist. (see below for nested schema)
+                          The items of the playlist.
                         items:
-                          description: |-
-                            (List of Object) The items of the playlist. (see below for nested schema)
-                            The items of the playlist.
-                          items:
-                            properties:
-                              type:
-                                description: (String)
-                                type: string
-                              value:
-                                description: (String)
-                                type: string
-                            type: object
-                          type: array
-                        title:
-                          description: |-
-                            (String) The title of the playlist.
-                            The title of the playlist.
-                          type: string
-                      type: object
-                    type: array
+                          properties:
+                            type:
+                              description: (String)
+                              type: string
+                            value:
+                              description: (String)
+                              type: string
+                          type: object
+                        type: array
+                      title:
+                        description: |-
+                          (String) The title of the playlist.
+                          The title of the playlist.
+                        type: string
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.


### PR DESCRIPTION
This PR updates the upjet replace directive to include the fix for SchemaNestingModeSingle blocks being generated as objects instead of arrays.

Previous replace directive fixed: blocks incorrectly marked as Computed=true
This update adds: blocks now use SchemaTypeObject instead of TypeList

Upstream PR: https://github.com/crossplane/upjet/pull/593