### PR TITLE
fix: upgrade Docker Buildx to v0.31.1 for API version compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Common versions
-  DOCKER_BUILDX_VERSION: 'v0.8.2'
+  DOCKER_BUILDX_VERSION: 'v0.31.1'
 
 jobs:
   detect-noop:
@@ -305,7 +305,6 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
-          install: 'true'
 
       - name: Get Upbound Credentials from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  DOCKER_BUILDX_VERSION: 'v0.8.2'
+  DOCKER_BUILDX_VERSION: 'v0.31.1'
 
 jobs:
   detect-noop:


### PR DESCRIPTION
## Summary
- Upgrades Docker Buildx from v0.8.2 to v0.31.1
- Removes deprecated `install: 'true'` parameter from setup-buildx-action

## Motivation
The old Docker Buildx v0.8.2 uses Docker client API version 1.42, which is incompatible with newer Docker daemons requiring API version 1.44+. This was causing CI failures with the error:
```
client version 1.42 is too old. Minimum supported API version is 1.44
```

## Changes
- Updated `DOCKER_BUILDX_VERSION` from v0.8.2 to v0.31.1 in both `ci.yaml` and `ci_tag.yaml`
- Removed deprecated `install: 'true'` parameter that triggers warnings

## Test Plan
- CI should pass with the updated Docker Buildx version