### PR TITLE
feat: add probeNames field to SM Check for automatic probe ID resolution

### DIFF
--- a/apis/cluster/sm/v1alpha1/zz_check_types.go
+++ b/apis/cluster/sm/v1alpha1/zz_check_types.go
@@ -217,6 +217,12 @@ type CheckInitParameters struct {
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
 
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
+
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.
 	Settings []SettingsInitParameters `json:"settings,omitempty" tf:"settings,omitempty"`
@@ -264,6 +270,12 @@ type CheckObservation struct {
 	// List of probe location IDs where this target will be checked from.
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
+
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
 
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.
@@ -320,6 +332,12 @@ type CheckParameters struct {
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
+
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
 
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.

--- a/apis/cluster/sm/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/sm/v1alpha1/zz_generated.deepcopy.go
@@ -712,6 +712,11 @@ func (in *CheckInitParameters) DeepCopyInto(out *CheckInitParameters) {
 			}
 		}
 	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
 		*out = make([]SettingsInitParameters, len(*in))
@@ -833,6 +838,11 @@ func (in *CheckObservation) DeepCopyInto(out *CheckObservation) {
 			}
 		}
 	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
 		*out = make([]SettingsObservation, len(*in))
@@ -921,6 +931,11 @@ func (in *CheckParameters) DeepCopyInto(out *CheckParameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -28,6 +28,9 @@ Copyright 2021 Upbound Inc.
 // Patch OnCall contact point types to add URLSecretRef field
 //go:generate bash ../hack/patch-oncall-urlsecretref.sh
 
+// Patch SM Check types to add custom ProbeNames field
+//go:generate bash ../hack/patch-sm-check-probenames.sh
+
 // Generate deepcopy methodsets and CRD manifests
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:allowDangerousTypes=true,crdVersions=v1 output:artifacts:config=../package/crds
 

--- a/apis/namespaced/sm/v1alpha1/zz_check_types.go
+++ b/apis/namespaced/sm/v1alpha1/zz_check_types.go
@@ -218,6 +218,12 @@ type CheckInitParameters struct {
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
 
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
+
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.
 	Settings []SettingsInitParameters `json:"settings,omitempty" tf:"settings,omitempty"`
@@ -265,6 +271,12 @@ type CheckObservation struct {
 	// List of probe location IDs where this target will be checked from.
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
+
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
 
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.
@@ -321,6 +333,12 @@ type CheckParameters struct {
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Probes []*float64 `json:"probes,omitempty" tf:"probes,omitempty"`
+
+	// CUSTOM FIELD: List of probe names to resolve to probe IDs.
+	// If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+	// This field is excluded from Terraform via tf:"-" tag.
+	// +kubebuilder:validation:Optional
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`
 
 	// (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see below for nested schema)
 	// Check settings. Should contain exactly one nested block.

--- a/apis/namespaced/sm/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/sm/v1alpha1/zz_generated.deepcopy.go
@@ -712,6 +712,11 @@ func (in *CheckInitParameters) DeepCopyInto(out *CheckInitParameters) {
 			}
 		}
 	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
 		*out = make([]SettingsInitParameters, len(*in))
@@ -833,6 +838,11 @@ func (in *CheckObservation) DeepCopyInto(out *CheckObservation) {
 			}
 		}
 	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
 		*out = make([]SettingsObservation, len(*in))
@@ -921,6 +931,11 @@ func (in *CheckParameters) DeepCopyInto(out *CheckParameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.ProbeNames != nil {
+		in, out := &in.ProbeNames, &out.ProbeNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.0
 	github.com/google/go-cmp v0.7.0
+	github.com/grafana/synthetic-monitoring-agent v0.43.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.17.1
 	github.com/grafana/terraform-provider-grafana/v4 v4.25.0
 	github.com/hashicorp/terraform-json v0.27.2
@@ -102,7 +103,6 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/grafana/river v0.3.0 // indirect
 	github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6 // indirect
-	github.com/grafana/synthetic-monitoring-agent v0.43.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.0
 	github.com/google/go-cmp v0.7.0
+	github.com/grafana/synthetic-monitoring-api-go-client v0.17.1
 	github.com/grafana/terraform-provider-grafana/v4 v4.25.0
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
@@ -102,7 +103,6 @@ require (
 	github.com/grafana/river v0.3.0 // indirect
 	github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6 // indirect
 	github.com/grafana/synthetic-monitoring-agent v0.43.1 // indirect
-	github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect

--- a/hack/patch-sm-check-probenames.sh
+++ b/hack/patch-sm-check-probenames.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Patch SM Check types to add ProbeNames field
+# This script is automatically run during 'make generate' after upjet generates types
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Patching SM Check types to add ProbeNames field..."
+
+for check_types in \
+  "${PROJECT_ROOT}/apis/namespaced/sm/v1alpha1/zz_check_types.go" \
+  "${PROJECT_ROOT}/apis/cluster/sm/v1alpha1/zz_check_types.go"; do
+
+  if [[ ! -f "${check_types}" ]]; then
+    echo "Warning: ${check_types} not found, skipping"
+    continue
+  fi
+
+  # Add ProbeNames field to CheckParameters struct (after Probes field)
+  # Using sed for reliable in-place replacement with proper whitespace
+  sed -i 's/\(	Probes \[\]\*float64 `json:"probes,omitempty" tf:"probes,omitempty"`\)/\1\
+\
+	\/\/ CUSTOM FIELD: List of probe names to resolve to probe IDs.\
+	\/\/ If set, this will override the Probes field with the resolved probe IDs on every reconciliation.\
+	\/\/ This field is excluded from Terraform via tf:"-" tag.\
+	\/\/ +kubebuilder:validation:Optional\
+	ProbeNames []string `json:"probeNames,omitempty" tf:"-"`/' "${check_types}"
+
+  echo "  Patched: ${check_types}"
+done
+
+echo "SM Check types patched successfully"

--- a/internal/clients/grafana.go
+++ b/internal/clients/grafana.go
@@ -195,6 +195,11 @@ func TerraformSetupBuilder() terraform.SetupFn {
 			return ps, errors.Wrap(err, errUnmarshalCredentials)
 		}
 
+		// Resolve ProbeNames to Probes for SM Check resources
+		if err := resolveSMCheckProbeNames(ctx, client, mg, creds, credSpec); err != nil {
+			return ps, errors.Wrap(err, "failed to resolve probe names")
+		}
+
 		// Set credentials in Terraform provider configuration.
 		// https://registry.terraform.io/providers/grafana/grafana/latest/docs
 		ps.Configuration = map[string]any{}

--- a/internal/clients/sm.go
+++ b/internal/clients/sm.go
@@ -1,0 +1,94 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clustersm "github.com/grafana/crossplane-provider-grafana/v2/apis/cluster/sm/v1alpha1"
+	namespacedsm "github.com/grafana/crossplane-provider-grafana/v2/apis/namespaced/sm/v1alpha1"
+)
+
+// resolveProbeNames resolves probe names to probe IDs using the SM API.
+// It returns the list of probe IDs corresponding to the given names.
+func resolveProbeNames(ctx context.Context, smURL, smAccessToken string, probeNames []string) ([]*float64, error) {
+	if smURL == "" || smAccessToken == "" {
+		return nil, errors.New("sm_url and sm_access_token are required to resolve probe names")
+	}
+
+	smClient := smapi.NewClient(smURL, smAccessToken, nil)
+	probes, err := smClient.ListProbes(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list probes from SM API")
+	}
+
+	// Build a map of probe name to ID
+	probeNameToID := make(map[string]int64)
+	for _, p := range probes {
+		probeNameToID[p.Name] = p.Id
+	}
+
+	// Resolve each name to an ID
+	probeIDs := make([]*float64, 0, len(probeNames))
+	var missingNames []string
+	for _, name := range probeNames {
+		if id, ok := probeNameToID[name]; ok {
+			idFloat := float64(id)
+			probeIDs = append(probeIDs, &idFloat)
+		} else {
+			missingNames = append(missingNames, name)
+		}
+	}
+
+	if len(missingNames) > 0 {
+		return nil, fmt.Errorf("probe names not found: %v", missingNames)
+	}
+
+	return probeIDs, nil
+}
+
+// resolveSMCheckProbeNames checks if the managed resource is an SM Check with ProbeNames set,
+// and if so, resolves the names to IDs and updates the Probes field.
+func resolveSMCheckProbeNames(ctx context.Context, c client.Client, mg resource.Managed, creds map[string]string, credSpec Config) error {
+	// Get SM credentials
+	smURL := creds["sm_url"]
+	if credSpec.SMURL != "" {
+		smURL = credSpec.SMURL
+	}
+	smAccessToken := creds["sm_access_token"]
+
+	// Check if this is an SM Check resource with ProbeNames set
+	switch check := mg.(type) {
+	case *clustersm.Check:
+		if len(check.Spec.ForProvider.ProbeNames) == 0 {
+			return nil
+		}
+		probeIDs, err := resolveProbeNames(ctx, smURL, smAccessToken, check.Spec.ForProvider.ProbeNames)
+		if err != nil {
+			return err
+		}
+		check.Spec.ForProvider.Probes = probeIDs
+		if err := c.Update(ctx, check); err != nil {
+			return errors.Wrap(err, "failed to update cluster SM Check with resolved probe IDs")
+		}
+
+	case *namespacedsm.Check:
+		if len(check.Spec.ForProvider.ProbeNames) == 0 {
+			return nil
+		}
+		probeIDs, err := resolveProbeNames(ctx, smURL, smAccessToken, check.Spec.ForProvider.ProbeNames)
+		if err != nil {
+			return err
+		}
+		check.Spec.ForProvider.Probes = probeIDs
+		if err := c.Update(ctx, check); err != nil {
+			return errors.Wrap(err, "failed to update namespaced SM Check with resolved probe IDs")
+		}
+	}
+
+	return nil
+}

--- a/internal/clients/sm.go
+++ b/internal/clients/sm.go
@@ -2,7 +2,11 @@ package clients
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
@@ -12,6 +16,21 @@ import (
 	clustersm "github.com/grafana/crossplane-provider-grafana/v2/apis/cluster/sm/v1alpha1"
 	namespacedsm "github.com/grafana/crossplane-provider-grafana/v2/apis/namespaced/sm/v1alpha1"
 )
+
+const (
+	// probeNamesHashAnnotation stores a hash of probeNames to detect changes
+	// and avoid unnecessary API calls on every reconciliation.
+	probeNamesHashAnnotation = "sm.grafana.crossplane.io/probe-names-hash"
+)
+
+// hashProbeNames computes a hash of the probe names for change detection.
+func hashProbeNames(names []string) string {
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+	h := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(h[:8]) // First 8 bytes is enough
+}
 
 // resolveProbeNames resolves probe names to probe IDs using the SM API.
 // It returns the list of probe IDs corresponding to the given names.
@@ -26,11 +45,14 @@ func resolveProbeNames(ctx context.Context, smURL, smAccessToken string, probeNa
 		return nil, errors.Wrap(err, "failed to list probes from SM API")
 	}
 
-	// Build a map of probe name to ID
+	// Build a map of probe name to ID and collect available names
 	probeNameToID := make(map[string]int64)
+	availableNames := make([]string, 0, len(probes))
 	for _, p := range probes {
 		probeNameToID[p.Name] = p.Id
+		availableNames = append(availableNames, p.Name)
 	}
+	sort.Strings(availableNames)
 
 	// Resolve each name to an ID
 	probeIDs := make([]*float64, 0, len(probeNames))
@@ -45,7 +67,11 @@ func resolveProbeNames(ctx context.Context, smURL, smAccessToken string, probeNa
 	}
 
 	if len(missingNames) > 0 {
-		return nil, fmt.Errorf("probe names not found: %v", missingNames)
+		return nil, fmt.Errorf("failed to resolve probe names to IDs. "+
+			"Requested probe names: %v. "+
+			"Probes not found: %v. "+
+			"Available probes: %v",
+			probeNames, missingNames, availableNames)
 	}
 
 	return probeIDs, nil
@@ -53,6 +79,7 @@ func resolveProbeNames(ctx context.Context, smURL, smAccessToken string, probeNa
 
 // resolveSMCheckProbeNames checks if the managed resource is an SM Check with ProbeNames set,
 // and if so, resolves the names to IDs and updates the Probes field.
+// It uses an annotation hash to avoid API calls when probeNames hasn't changed.
 func resolveSMCheckProbeNames(ctx context.Context, c client.Client, mg resource.Managed, creds map[string]string, credSpec Config) error {
 	// Get SM credentials
 	smURL := creds["sm_url"]
@@ -67,11 +94,28 @@ func resolveSMCheckProbeNames(ctx context.Context, c client.Client, mg resource.
 		if len(check.Spec.ForProvider.ProbeNames) == 0 {
 			return nil
 		}
+
+		// Check if hash matches to skip API call
+		currentHash := hashProbeNames(check.Spec.ForProvider.ProbeNames)
+		annotations := check.GetAnnotations()
+		if annotations != nil && annotations[probeNamesHashAnnotation] == currentHash {
+			// Hash matches, probeNames unchanged - skip API call
+			return nil
+		}
+
 		probeIDs, err := resolveProbeNames(ctx, smURL, smAccessToken, check.Spec.ForProvider.ProbeNames)
 		if err != nil {
 			return err
 		}
+
+		// Update probes and set hash annotation
 		check.Spec.ForProvider.Probes = probeIDs
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[probeNamesHashAnnotation] = currentHash
+		check.SetAnnotations(annotations)
+
 		if err := c.Update(ctx, check); err != nil {
 			return errors.Wrap(err, "failed to update cluster SM Check with resolved probe IDs")
 		}
@@ -80,11 +124,28 @@ func resolveSMCheckProbeNames(ctx context.Context, c client.Client, mg resource.
 		if len(check.Spec.ForProvider.ProbeNames) == 0 {
 			return nil
 		}
+
+		// Check if hash matches to skip API call
+		currentHash := hashProbeNames(check.Spec.ForProvider.ProbeNames)
+		annotations := check.GetAnnotations()
+		if annotations != nil && annotations[probeNamesHashAnnotation] == currentHash {
+			// Hash matches, probeNames unchanged - skip API call
+			return nil
+		}
+
 		probeIDs, err := resolveProbeNames(ctx, smURL, smAccessToken, check.Spec.ForProvider.ProbeNames)
 		if err != nil {
 			return err
 		}
+
+		// Update probes and set hash annotation
 		check.Spec.ForProvider.Probes = probeIDs
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[probeNamesHashAnnotation] = currentHash
+		check.SetAnnotations(annotations)
+
 		if err := c.Update(ctx, check); err != nil {
 			return errors.Wrap(err, "failed to update namespaced SM Check with resolved probe IDs")
 		}

--- a/internal/clients/sm_integration_test.go
+++ b/internal/clients/sm_integration_test.go
@@ -1,0 +1,92 @@
+package clients
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+/*
+Integration tests for SM Check probe name resolution.
+
+To run these tests locally, you need a Grafana Cloud stack with Synthetic Monitoring enabled.
+
+Environment variables:
+  SM_URL          - SM API URL (default: https://synthetic-monitoring-api-dev.grafana.net)
+  SM_ACCESS_TOKEN - SM API access token (required)
+  SM_PROBE_NAMES  - Comma-separated probe names to test (default: Paris,Oregon,Spain)
+
+Run with:
+  source .env && go test -v ./internal/clients/... -run Integration
+
+To get SM credentials:
+1. Go to your Grafana Cloud portal
+2. Navigate to Synthetic Monitoring > Config
+3. Generate or copy the API access token
+*/
+
+const (
+	defaultSMURL      = "https://synthetic-monitoring-api-dev.grafana.net"
+	defaultProbeNames = "Paris,Oregon,Spain"
+)
+
+// TestIntegration_ResolveProbeNames tests probe name resolution against a real SM API.
+func TestIntegration_ResolveProbeNames(t *testing.T) {
+	smURL := os.Getenv("SM_URL")
+	if smURL == "" {
+		smURL = defaultSMURL
+	}
+
+	smToken := os.Getenv("SM_ACCESS_TOKEN")
+	if smToken == "" {
+		t.Skip("Skipping integration test: SM_ACCESS_TOKEN environment variable not set")
+	}
+
+	probeNamesEnv := os.Getenv("SM_PROBE_NAMES")
+	if probeNamesEnv == "" {
+		probeNamesEnv = defaultProbeNames
+	}
+	probeNames := strings.Split(probeNamesEnv, ",")
+
+	ctx := context.Background()
+
+	// Test resolving a single probe name
+	probeIDs, err := resolveProbeNames(ctx, smURL, smToken, []string{probeNames[0]})
+	if err != nil {
+		t.Fatalf("failed to resolve probe name %q: %v", probeNames[0], err)
+	}
+	if len(probeIDs) != 1 {
+		t.Errorf("expected 1 probe ID, got %d", len(probeIDs))
+	}
+	t.Logf("Successfully resolved %q to ID %v", probeNames[0], *probeIDs[0])
+
+	// Test resolving multiple probe names
+	probeIDs, err = resolveProbeNames(ctx, smURL, smToken, probeNames)
+	if err != nil {
+		t.Fatalf("failed to resolve probe names %v: %v", probeNames, err)
+	}
+	if len(probeIDs) != len(probeNames) {
+		t.Errorf("expected %d probe IDs, got %d", len(probeNames), len(probeIDs))
+	}
+	t.Logf("Successfully resolved %v to IDs: %v", probeNames, probeIDsToString(probeIDs))
+
+	// Test error case: non-existent probe name
+	_, err = resolveProbeNames(ctx, smURL, smToken, []string{"NonExistentProbeName12345"})
+	if err == nil {
+		t.Error("expected error for non-existent probe name, got nil")
+	} else {
+		t.Logf("Correctly got error for non-existent probe: %v", err)
+	}
+}
+
+// probeIDsToString converts probe IDs to a string for logging.
+func probeIDsToString(ids []*float64) []float64 {
+	result := make([]float64, len(ids))
+	for i, id := range ids {
+		if id != nil {
+			result[i] = *id
+		}
+	}
+	return result
+}

--- a/internal/clients/sm_test.go
+++ b/internal/clients/sm_test.go
@@ -1,0 +1,350 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	synthetic_monitoring "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clustersm "github.com/grafana/crossplane-provider-grafana/v2/apis/cluster/sm/v1alpha1"
+	namespacedsm "github.com/grafana/crossplane-provider-grafana/v2/apis/namespaced/sm/v1alpha1"
+)
+
+func createSMScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = clustersm.SchemeBuilder.AddToScheme(scheme)
+	_ = namespacedsm.SchemeBuilder.AddToScheme(scheme)
+	return scheme
+}
+
+func createMockSMServer(t *testing.T, probes []synthetic_monitoring.Probe) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/probe/list" {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(probes); err != nil {
+				t.Fatalf("failed to encode probes: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+// TestResolveProbeNames verifies that probe names are correctly resolved to IDs via the SM API.
+func TestResolveProbeNames(t *testing.T) {
+	cases := []struct {
+		name          string
+		probes        []synthetic_monitoring.Probe
+		probeNames    []string
+		wantIDs       []*float64
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name: "resolves single probe name",
+			probes: []synthetic_monitoring.Probe{
+				{Id: 1, Name: "Amsterdam"},
+				{Id: 2, Name: "New York"},
+			},
+			probeNames: []string{"Amsterdam"},
+			wantIDs:    []*float64{float64Ptr(1.0)},
+		},
+		{
+			name: "resolves multiple probe names",
+			probes: []synthetic_monitoring.Probe{
+				{Id: 1, Name: "Amsterdam"},
+				{Id: 2, Name: "New York"},
+				{Id: 3, Name: "Tokyo"},
+			},
+			probeNames: []string{"Amsterdam", "Tokyo"},
+			wantIDs:    []*float64{float64Ptr(1.0), float64Ptr(3.0)},
+		},
+		{
+			name: "returns error for missing probe name",
+			probes: []synthetic_monitoring.Probe{
+				{Id: 1, Name: "Amsterdam"},
+			},
+			probeNames:    []string{"Amsterdam", "NonExistent"},
+			wantErr:       true,
+			wantErrSubstr: "probe names not found: [NonExistent]",
+		},
+		{
+			name: "returns error for all missing probe names",
+			probes: []synthetic_monitoring.Probe{
+				{Id: 1, Name: "Amsterdam"},
+			},
+			probeNames:    []string{"NonExistent1", "NonExistent2"},
+			wantErr:       true,
+			wantErrSubstr: "probe names not found:",
+		},
+		{
+			name:       "handles empty probe names list",
+			probes:     []synthetic_monitoring.Probe{{Id: 1, Name: "Amsterdam"}},
+			probeNames: []string{},
+			wantIDs:    []*float64{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := createMockSMServer(t, tc.probes)
+			defer server.Close()
+
+			ids, err := resolveProbeNames(context.Background(), server.URL, "test-token", tc.probeNames)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+				}
+				if tc.wantErrSubstr != "" && !containsSubstring(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("expected error containing %q, got %q", tc.wantErrSubstr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantIDs, ids); diff != "" {
+				t.Errorf("probe IDs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestResolveProbeNamesMissingCredentials verifies that an error is returned when SM credentials are missing.
+func TestResolveProbeNamesMissingCredentials(t *testing.T) {
+	cases := []struct {
+		name       string
+		smURL      string
+		smToken    string
+		wantErrMsg string
+	}{
+		{
+			name:       "missing SM URL",
+			smURL:      "",
+			smToken:    "token",
+			wantErrMsg: "sm_url and sm_access_token are required",
+		},
+		{
+			name:       "missing SM token",
+			smURL:      "http://example.com",
+			smToken:    "",
+			wantErrMsg: "sm_url and sm_access_token are required",
+		},
+		{
+			name:       "missing both",
+			smURL:      "",
+			smToken:    "",
+			wantErrMsg: "sm_url and sm_access_token are required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveProbeNames(context.Background(), tc.smURL, tc.smToken, []string{"test"})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !containsSubstring(err.Error(), tc.wantErrMsg) {
+				t.Errorf("expected error containing %q, got %q", tc.wantErrMsg, err.Error())
+			}
+		})
+	}
+}
+
+// TestResolveSMCheckProbeNames_ClusterCheck verifies probe name resolution for cluster-scoped SM Check resources.
+func TestResolveSMCheckProbeNames_ClusterCheck(t *testing.T) {
+	probes := []synthetic_monitoring.Probe{
+		{Id: 1, Name: "Amsterdam"},
+		{Id: 2, Name: "New York"},
+	}
+	server := createMockSMServer(t, probes)
+	defer server.Close()
+
+	check := &clustersm.Check{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-check",
+		},
+		Spec: clustersm.CheckSpec{
+			ForProvider: clustersm.CheckParameters{
+				ProbeNames: []string{"Amsterdam", "New York"},
+			},
+		},
+	}
+
+	scheme := createSMScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(check).
+		Build()
+
+	creds := map[string]string{
+		"sm_url":          server.URL,
+		"sm_access_token": "test-token",
+	}
+
+	err := resolveSMCheckProbeNames(context.Background(), client, check, creds, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the check was updated with probe IDs
+	updatedCheck := &clustersm.Check{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "test-check"}, updatedCheck); err != nil {
+		t.Fatalf("failed to get updated check: %v", err)
+	}
+
+	wantProbes := []*float64{float64Ptr(1.0), float64Ptr(2.0)}
+	if diff := cmp.Diff(wantProbes, updatedCheck.Spec.ForProvider.Probes); diff != "" {
+		t.Errorf("probes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestResolveSMCheckProbeNames_NamespacedCheck verifies probe name resolution for namespaced SM Check resources.
+func TestResolveSMCheckProbeNames_NamespacedCheck(t *testing.T) {
+	probes := []synthetic_monitoring.Probe{
+		{Id: 10, Name: "Tokyo"},
+		{Id: 20, Name: "Sydney"},
+	}
+	server := createMockSMServer(t, probes)
+	defer server.Close()
+
+	check := &namespacedsm.Check{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-check",
+			Namespace: "default",
+		},
+		Spec: namespacedsm.CheckSpec{
+			ForProvider: namespacedsm.CheckParameters{
+				ProbeNames: []string{"Tokyo"},
+			},
+		},
+	}
+
+	scheme := createSMScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(check).
+		Build()
+
+	creds := map[string]string{
+		"sm_url":          server.URL,
+		"sm_access_token": "test-token",
+	}
+
+	err := resolveSMCheckProbeNames(context.Background(), client, check, creds, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the check was updated with probe IDs
+	updatedCheck := &namespacedsm.Check{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "test-check", Namespace: "default"}, updatedCheck); err != nil {
+		t.Fatalf("failed to get updated check: %v", err)
+	}
+
+	wantProbes := []*float64{float64Ptr(10.0)}
+	if diff := cmp.Diff(wantProbes, updatedCheck.Spec.ForProvider.Probes); diff != "" {
+		t.Errorf("probes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestResolveSMCheckProbeNames_NoProbeNames verifies that no API call is made when ProbeNames is empty.
+func TestResolveSMCheckProbeNames_NoProbeNames(t *testing.T) {
+	check := &clustersm.Check{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-check",
+		},
+		Spec: clustersm.CheckSpec{
+			ForProvider: clustersm.CheckParameters{
+				// ProbeNames is nil/empty
+			},
+		},
+	}
+
+	scheme := createSMScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(check).
+		Build()
+
+	// No SM server - should not be called
+	creds := map[string]string{}
+
+	err := resolveSMCheckProbeNames(context.Background(), client, check, creds, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestResolveSMCheckProbeNames_SMURLFromCredSpec verifies that SM URL from Config overrides the credentials map.
+func TestResolveSMCheckProbeNames_SMURLFromCredSpec(t *testing.T) {
+	probes := []synthetic_monitoring.Probe{
+		{Id: 1, Name: "Amsterdam"},
+	}
+	server := createMockSMServer(t, probes)
+	defer server.Close()
+
+	check := &clustersm.Check{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-check",
+		},
+		Spec: clustersm.CheckSpec{
+			ForProvider: clustersm.CheckParameters{
+				ProbeNames: []string{"Amsterdam"},
+			},
+		},
+	}
+
+	scheme := createSMScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(check).
+		Build()
+
+	// SM URL from credSpec should override creds
+	creds := map[string]string{
+		"sm_url":          "http://wrong-url",
+		"sm_access_token": "test-token",
+	}
+	credSpec := Config{
+		SMURL: server.URL, // This should be used instead
+	}
+
+	err := resolveSMCheckProbeNames(context.Background(), client, check, creds, credSpec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Helper functions
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && searchSubstring(s, substr)))
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/clients/sm_test.go
+++ b/internal/clients/sm_test.go
@@ -380,8 +380,8 @@ func TestResolveSMCheckProbeNames_AnnotationHash(t *testing.T) {
 
 	// Fetch the updated check with annotation
 	updatedCheck := &clustersm.Check{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: "test-check"}, updatedCheck); err != nil {
-		t.Fatalf("failed to get updated check: %v", err)
+	if getErr := client.Get(context.Background(), types.NamespacedName{Name: "test-check"}, updatedCheck); getErr != nil {
+		t.Fatalf("failed to get updated check: %v", getErr)
 	}
 
 	// Verify annotation was set
@@ -407,8 +407,8 @@ func TestResolveSMCheckProbeNames_AnnotationHash(t *testing.T) {
 	ann = updatedCheck.GetAnnotations()
 	ann[probeNamesHashAnnotation] = "different-hash"
 	updatedCheck.SetAnnotations(ann)
-	if err := client.Update(context.Background(), updatedCheck); err != nil {
-		t.Fatalf("failed to update check: %v", err)
+	if updateErr := client.Update(context.Background(), updatedCheck); updateErr != nil {
+		t.Fatalf("failed to update check: %v", updateErr)
 	}
 
 	err = resolveSMCheckProbeNames(context.Background(), client, updatedCheck, creds, Config{})
@@ -423,10 +423,10 @@ func TestResolveSMCheckProbeNames_AnnotationHash(t *testing.T) {
 // TestHashProbeNames verifies the hash function produces consistent results.
 func TestHashProbeNames(t *testing.T) {
 	cases := []struct {
-		name    string
-		input1  []string
-		input2  []string
-		wantEq  bool
+		name   string
+		input1 []string
+		input2 []string
+		wantEq bool
 	}{
 		{
 			name:   "same names same order",

--- a/package/crds/sm.grafana.crossplane.io_checks.yaml
+++ b/package/crds/sm.grafana.crossplane.io_checks.yaml
@@ -111,6 +111,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.
@@ -935,6 +943,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.
@@ -1859,6 +1875,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.

--- a/package/crds/sm.grafana.m.crossplane.io_checks.yaml
+++ b/package/crds/sm.grafana.m.crossplane.io_checks.yaml
@@ -97,6 +97,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.
@@ -896,6 +904,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.
@@ -1767,6 +1783,14 @@ spec:
                       Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
                     type: object
                     x-kubernetes-map-type: granular
+                  probeNames:
+                    description: |-
+                      CUSTOM FIELD: List of probe names to resolve to probe IDs.
+                      If set, this will override the Probes field with the resolved probe IDs on every reconciliation.
+                      This field is excluded from Terraform via tf:"-" tag.
+                    items:
+                      type: string
+                    type: array
                   probes:
                     description: |-
                       (Set of Number) List of probe location IDs where this target will be checked from.


### PR DESCRIPTION
## Summary

- Adds a `probeNames` field to SM Check resources that accepts probe names instead of numeric IDs
- Automatically resolves probe names to IDs using the SM API
- Uses annotation-based caching to avoid redundant API calls (~6 calls/hour per Check saved)
- Makes SM Check configurations more portable across environments where probe IDs may differ

This replaces the hackish implementation from [grafana/crossplane-function-grafana-data](https://github.com/grafana/crossplane-function-grafana-data) in regards to SM check probes, moving the probe name resolution into the provider itself.

## Changes

- `internal/clients/sm.go`: New file with `resolveProbeNames()` and `resolveSMCheckProbeNames()` functions
- `internal/clients/grafana.go`: Calls probe name resolution in `TerraformSetupBuilder`
- `hack/patch-sm-check-probenames.sh`: Patches generated types to add `ProbeNames` field
- `apis/generate.go`: Runs patch script during code generation

## Usage

```yaml
apiVersion: sm.grafana.crossplane.io/v1alpha1
kind: Check
spec:
  forProvider:
    probeNames:
      - "Paris"
      - "Oregon"
      - "Spain"
    # probes field will be auto-populated with resolved IDs
```

## Performance

The implementation uses an annotation hash (`sm.grafana.crossplane.io/probe-names-hash`) to detect changes to `probeNames`. The SM API is only called when:
- First reconciliation (no hash annotation exists)
- `probeNames` array changes (hash mismatch)

At the default 10-minute reconciliation interval, this avoids ~6 API calls per hour per Check resource. For installations with hundreds of SM Checks, this significantly reduces load on the SM API.

## Error Messages

When probe names aren't found, the error message includes helpful context:
```
failed to resolve probe names to IDs.
Requested probe names: [Paris Oregon InvalidName].
Probes not found: [InvalidName].
Available probes: [Amsterdam Atlanta Frankfurt London Paris Oregon Tokyo]
```

## Reviewer Tips

- **Core logic**: `internal/clients/sm.go` (~155 lines) - resolves probe names via SM API with hash-based caching
- **Type patching**: `hack/patch-sm-check-probenames.sh` adds `ProbeNames` field with `tf:"-"` tag to generated types
- **Test locally**: `go test -v ./internal/clients/... -run "SM|Probe|Hash"` (no credentials needed)

## Test plan

- [x] Unit tests for `resolveProbeNames` and `resolveSMCheckProbeNames`
- [x] Unit tests for annotation hash caching behavior
- [x] Unit tests for comprehensive error message format
- [x] Integration test (run with `source .env && go test -v ./internal/clients/... -run Integration`)
- [ ] Manual testing with a real SM instance