### PR TITLE
chore: remove code coverage checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,12 +218,6 @@ jobs:
       - name: Run Unit Tests
         run: make -j2 test
 
-      - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          flags: unittests
-          file: _output/tests/linux_amd64/coverage.txt
-
   local-deploy:
     runs-on: ubuntu-24.04
     needs: detect-noop

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -146,12 +146,6 @@ jobs:
       - name: Run Unit Tests
         run: make -j2 test
 
-      - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          flags: unittests
-          file: _output/tests/linux_amd64/coverage.txt
-
   local-deploy:
     runs-on: ubuntu-24.04
     needs: detect-noop

--- a/Makefile
+++ b/Makefile
@@ -142,13 +142,6 @@ generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
 go.cachedir:
 	@go env GOCACHE
 
-# Generate a coverage report for cobertura applying exclusions on
-# - generated file
-cobertura:
-	@cat $(GO_TEST_OUTPUT)/coverage.txt | \
-		grep -v zz_ | \
-		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
-
 # Update the submodules, such as the common build scripts.
 submodules:
 	@git submodule sync
@@ -213,14 +206,13 @@ schema-version-diff:
 	./scripts/version_diff.py config/generated.lst "$(WORK_DIR)/schema.json.$${PREV_PROVIDER_VERSION}" config/schema.json
 	@$(OK) Checking for native state schema version changes
 
-.PHONY: cobertura submodules fallthrough run crds.clean
+.PHONY: submodules fallthrough run crds.clean
 
 # ====================================================================================
 # Special Targets
 
 define CROSSPLANE_MAKE_HELP
 Crossplane Targets:
-    cobertura             Generate a coverage report for cobertura applying exclusions on generated files.
     submodules            Update the submodules, such as the common build scripts.
     run                   Run crossplane locally, out-of-cluster. Useful for development.
 


### PR DESCRIPTION
Removes non-functional code coverage checks from CI workflows and Makefile. These never worked as we do not have a codecov token.