### PR TITLE
fix: use computedFieldExtractor for oncall.url reference

### DIFF
--- a/apis/cluster/alerting/v1alpha1/zz_contactpoint_types.go
+++ b/apis/cluster/alerting/v1alpha1/zz_contactpoint_types.go
@@ -1410,7 +1410,7 @@ type OncallInitParameters struct {
 	// (String) The URL of the Alertmanager instance.
 	// The URL to send webhook requests to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/v2/apis/cluster/oncall/v1alpha1.Integration
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.FieldExtractor("link")
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.ComputedFieldExtractor("link")
 	// +crossplane:generate:reference:refFieldName=OncallIntegrationRef
 	// +crossplane:generate:reference:selectorFieldName=OncallIntegrationSelector
 	URL *string `json:"url,omitempty" tf:"url,omitempty"`
@@ -1518,7 +1518,7 @@ type OncallParameters struct {
 	// (String) The URL of the Alertmanager instance.
 	// The URL to send webhook requests to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/v2/apis/cluster/oncall/v1alpha1.Integration
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.FieldExtractor("link")
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.ComputedFieldExtractor("link")
 	// +crossplane:generate:reference:refFieldName=OncallIntegrationRef
 	// +crossplane:generate:reference:selectorFieldName=OncallIntegrationSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/alerting/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cluster/alerting/v1alpha1/zz_generated.resolvers.go
@@ -25,7 +25,7 @@ func (mg *ContactPoint) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Oncall); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Oncall[i3].URL),
-			Extract:      grafana.FieldExtractor("link"),
+			Extract:      grafana.ComputedFieldExtractor("link"),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.Oncall[i3].OncallIntegrationRef,
 			Selector:     mg.Spec.ForProvider.Oncall[i3].OncallIntegrationSelector,
@@ -61,7 +61,7 @@ func (mg *ContactPoint) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Oncall); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Oncall[i3].URL),
-			Extract:      grafana.FieldExtractor("link"),
+			Extract:      grafana.ComputedFieldExtractor("link"),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.InitProvider.Oncall[i3].OncallIntegrationRef,
 			Selector:     mg.Spec.InitProvider.Oncall[i3].OncallIntegrationSelector,

--- a/apis/namespaced/alerting/v1alpha1/zz_contactpoint_types.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_contactpoint_types.go
@@ -1411,7 +1411,7 @@ type OncallInitParameters struct {
 	// (String) The URL of the Alertmanager instance.
 	// The URL to send webhook requests to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/v2/apis/namespaced/oncall/v1alpha1.Integration
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.FieldExtractor("link")
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.ComputedFieldExtractor("link")
 	// +crossplane:generate:reference:refFieldName=OncallIntegrationRef
 	// +crossplane:generate:reference:selectorFieldName=OncallIntegrationSelector
 	URL *string `json:"url,omitempty" tf:"url,omitempty"`
@@ -1519,7 +1519,7 @@ type OncallParameters struct {
 	// (String) The URL of the Alertmanager instance.
 	// The URL to send webhook requests to.
 	// +crossplane:generate:reference:type=github.com/grafana/crossplane-provider-grafana/v2/apis/namespaced/oncall/v1alpha1.Integration
-	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.FieldExtractor("link")
+	// +crossplane:generate:reference:extractor=github.com/grafana/crossplane-provider-grafana/v2/config/grafana.ComputedFieldExtractor("link")
 	// +crossplane:generate:reference:refFieldName=OncallIntegrationRef
 	// +crossplane:generate:reference:selectorFieldName=OncallIntegrationSelector
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/alerting/v1alpha1/zz_generated.resolvers.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_generated.resolvers.go
@@ -25,7 +25,7 @@ func (mg *ContactPoint) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Oncall); i3++ {
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Oncall[i3].URL),
-			Extract:      grafana.FieldExtractor("link"),
+			Extract:      grafana.ComputedFieldExtractor("link"),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.Oncall[i3].OncallIntegrationRef,
 			Selector:     mg.Spec.ForProvider.Oncall[i3].OncallIntegrationSelector,
@@ -61,7 +61,7 @@ func (mg *ContactPoint) ResolveReferences(ctx context.Context, c client.Reader) 
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Oncall); i3++ {
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Oncall[i3].URL),
-			Extract:      grafana.FieldExtractor("link"),
+			Extract:      grafana.ComputedFieldExtractor("link"),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.InitProvider.Oncall[i3].OncallIntegrationRef,
 			Selector:     mg.Spec.InitProvider.Oncall[i3].OncallIntegrationSelector,

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -439,7 +439,7 @@ func Configure(p *ujconfig.Provider) {
 			TerraformName:     "grafana_oncall_integration",
 			RefFieldName:      "OncallIntegrationRef",
 			SelectorFieldName: "OncallIntegrationSelector",
-			Extractor:         fieldExtractor("link"),
+			Extractor:         computedFieldExtractor("link"),
 		}
 	})
 	p.AddResourceConfigurator("grafana_report", func(r *ujconfig.Resource) {


### PR DESCRIPTION
Fixes reference resolution for contact point oncall.url field. The link field exists in status.atProvider (computed), not spec.forProvider.