### PR TITLE
chore(renovate): disable auto-updates for controller-runtime and controller-tools

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,15 @@
       automergeStrategy: 'squash',
     },
     {
+      // Disable auto-updates for controller-runtime and controller-tools
+      // These must be updated manually alongside crossplane-runtime due to API compatibility
+      matchPackagePatterns: [
+        '^sigs\\.k8s\\.io/controller-runtime',
+        '^sigs\\.k8s\\.io/controller-tools',
+      ],
+      enabled: false,
+    },
+    {
       // When terraform-provider-grafana is updated, run make submodules and make generate
       matchPackageNames: ['github.com/grafana/terraform-provider-grafana/v4'],
       postUpgradeTasks: {


### PR DESCRIPTION
## Summary

Disables Renovate auto-updates for `controller-runtime` and `controller-tools` dependencies. These packages have API compatibility requirements with `crossplane-runtime` and must be updated together manually.

## Background

PRs #387 and #388 demonstrate the issue:
- **PR #387** (controller-runtime v0.23.1): Multiple compilation failures due to missing `Apply` method in crossplane-runtime's `SubResourceWriter` implementation
- **PR #388** (controller-tools v0.20.1): CRD generation changes that don't match current output

Both failures stem from crossplane-runtime v2.1.0 being incompatible with the newer controller-runtime APIs these updates introduce.

## Changes

Added Renovate package rule to disable automatic updates for:
- `sigs.k8s.io/controller-runtime`
- `sigs.k8s.io/controller-tools`

These will now only be updated manually when crossplane-runtime supports the required API versions.

## Related

Closes #387
Closes #388