### PR TITLE
ci: parallelize build and publish jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,7 +378,7 @@ jobs:
           path: _output
 
       - name: Install Crossplane CLI
-        run: make $( make build.vars 2>&1 | sed -n 's/^CROSSPLANE_CLI=//p' )
+        run: make build.init
 
       - name: Get Upbound Credentials from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,22 +269,24 @@ jobs:
         run: make local-deploy
 
   build-artifacts:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     permissions:
       contents: read
+    strategy:
+      matrix:
+        include:
+          - platform: linux_amd64
+            runner: ubuntu-24.04
+          - platform: linux_arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          platforms: all
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -313,21 +315,21 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-publish-artifacts-
+          key: ${{ runner.os }}-${{ runner.arch }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
+          key: ${{ runner.os }}-${{ runner.arch }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-pkg-
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
       - name: Build Artifacts
-        run: make -j2 build.all
+        run: make -j2 build.all PLATFORMS=${{ matrix.platform }}
         env:
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
@@ -336,7 +338,7 @@ jobs:
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: output
+          name: output-${{ matrix.platform }}
           path: _output/**
 
   publish-artifacts:
@@ -374,8 +376,9 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: output
+          pattern: output-*
           path: _output
+          merge-multiple: true
 
       - name: Install Crossplane CLI
         run: make build.init

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,21 +268,12 @@ jobs:
       - name: Deploying locally built provider package
         run: make local-deploy
 
-  publish-artifacts:
+  build-artifacts:
     runs-on: ubuntu-24.04
-    # Explicitly set permissions for this job
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-    needs:
-      - detect-noop
-      - report-breaking-changes
-      - lint
-      - check-diff
-      - unit-tests
-      - local-deploy
+    needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
+    permissions:
+      contents: read
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -299,28 +290,6 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
-
-      - name: Get Upbound Credentials from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          common_secrets: |
-            UPBOUND_MARKETPLACE_PUSH_ROBOT_ID=upbound:access-id
-            UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN=upbound:token
-
-      - name: Login to Upbound
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
-        with:
-          registry: xpkg.upbound.io
-          username: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID }}
-          password: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -369,6 +338,66 @@ jobs:
         with:
           name: output
           path: _output/**
+
+  publish-artifacts:
+    runs-on: ubuntu-24.04
+    # Explicitly set permissions for this job
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+    needs:
+      - detect-noop
+      - report-breaking-changes
+      - lint
+      - check-diff
+      - unit-tests
+      - local-deploy
+      - build-artifacts
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: output
+          path: _output
+
+      - name: Get Upbound Credentials from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
+        with:
+          common_secrets: |
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_ID=upbound:access-id
+            UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN=upbound:token
+
+      - name: Login to Upbound
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID }}
+          password: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifacts to Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,6 +377,9 @@ jobs:
           name: output
           path: _output
 
+      - name: Install Crossplane CLI
+        run: make $( make build.vars 2>&1 | sed -n 's/^CROSSPLANE_CLI=//p' )
+
       - name: Get Upbound Credentials from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,6 @@ GO_SUBDIRS += cmd internal apis
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.30.0
-UP_VERSION = v0.41.0
-UP_CHANNEL = stable
 UPTEST_VERSION = v2.1.0
 CRDDIFF_VERSION = v0.12.1
 -include build/makelib/k8s_tools.mk
@@ -95,7 +93,7 @@ xpkg.build.provider-grafana: do.build.images
 
 # NOTE(hasheddan): we ensure up is installed prior to running platform-specific
 # build steps in parallel to avoid encountering an installation race condition.
-build.init: $(CROSSPLANE_CLI) $(UP)
+build.init: $(CROSSPLANE_CLI)
 
 # ====================================================================================
 # Setup Terraform for fetching provider schema


### PR DESCRIPTION
## Summary
- Split `publish-artifacts` into `build-artifacts` + `publish-artifacts` jobs
- `build-artifacts` uses a matrix strategy with native runners per architecture (`ubuntu-24.04` for amd64, `ubuntu-24.04-arm` for arm64), eliminating QEMU emulation
- `publish-artifacts` downloads pre-built artifacts via `actions/download-artifact` instead of rebuilding
- Removes unused `UP_VERSION`/`UP_CHANNEL` variables and `$(UP)` dependency from `build.init`

## Dependency graph
```
detect-noop
├── report-breaking-changes  ─┐
├── lint                      │
├── check-diff                ├──► publish-artifacts
├── unit-tests                │
├── local-deploy             ─┘
└── build-artifacts          ─┘  (matrix: amd64 + arm64, parallel with above)
```

## Timing comparison

Baseline: [run 22962079845](https://github.com/grafana/crossplane-provider-grafana/actions/runs/22962079845) (old single-job structure on `renovate/go-golang.org-x-net-vulnerability`)
New (cold cache): [run 22979748353](https://github.com/grafana/crossplane-provider-grafana/actions/runs/22979748353) (this PR, native runners, caches cleared before run)

| Job | Baseline | New (cold cache) |
|---|---|---|
| detect-noop | 0m18s | 0m14s |
| report-breaking-changes | 0m16s | 0m15s |
| lint | 6m10s | 5m58s |
| check-diff | 3m13s | 3m18s |
| unit-tests | 7m15s | 7m13s |
| local-deploy | 6m32s | 6m42s |
| build-artifacts (amd64) | — | 5m26s |
| build-artifacts (arm64) | — | 4m26s |
| publish-artifacts (build+publish) | 10m01s | 0m46s |
| **Total wall time** | **17m40s** | **8m19s** |

**53% reduction in total wall time** (17m40s → 8m19s). The check jobs have comparable timings (cold caches on both), confirming the speedup is structural:
1. Build runs in parallel with checks instead of sequentially after them
2. Native arm64 runner eliminates QEMU emulation overhead (old publish-artifacts did both build+publish in 10m01s; new build is 5m26s amd64 / 4m26s arm64 + 0m46s publish)

## Native vs QEMU build comparison

Compared the images published by the QEMU build (`v2.5.0-23.g3be42c4`) and the native runner build (`v2.5.0-24.gdc7e968`) using `docker export` and file-level diffing:

| | linux/amd64 | linux/arm64 |
|---|---|---|
| File list | Identical | Identical |
| Files identical | 364 | 334 |
| Files differ | 2 | 2 |
| Differing files | `provider` binary, `apk.log` | `provider` binary, `apk.log` |
| Binary size | 119,783,608 (same) | 112,263,352 (same) |
| Bytes differ in binary | 189 | 188 |

The only differences are:
- **`/usr/local/bin/provider`**: ~188 bytes differ, consistent with the embedded version string change (`g3be42c4` → `gdc7e968` via `-ldflags`)
- **`/var/log/apk.log`**: timestamp of when `apk add` ran during docker build

Native-runner builds produce functionally identical images to the QEMU builds.

## Test plan
- [x] Verify workflow graph shows `build-artifacts` running in parallel with check jobs
- [x] Verify `build-artifacts` completes successfully for both amd64 and arm64
- [x] Verify `publish-artifacts` downloads and merges artifacts, publishes successfully
- [x] Compare image contents between QEMU and native builds (see table above)
- [x] Compare total workflow duration against baseline with cold caches (see timing table above)