### PR TITLE
chore(docker): remove unused terraform binaries from image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ export TERRAFORM_VERSION := 1.7.5
 export TERRAFORM_PROVIDER_SOURCE := grafana/grafana
 export TERRAFORM_PROVIDER_REPO := https://github.com/grafana/terraform-provider-grafana
 export TERRAFORM_PROVIDER_VERSION := $(shell grep terraform-provider-grafana go.mod | awk '{print $$2}' | sed 's/v//')
-export TERRAFORM_PROVIDER_DOWNLOAD_NAME := terraform-provider-grafana
-export TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX := https://releases.hashicorp.com/$(TERRAFORM_PROVIDER_DOWNLOAD_NAME)/v$(TERRAFORM_PROVIDER_VERSION)
-export TERRAFORM_NATIVE_PROVIDER_BINARY := $(TERRAFORM_PROVIDER_DOWNLOAD_NAME)_v$(TERRAFORM_PROVIDER_VERSION)
 export TERRAFORM_DOCS_PATH := docs/resources
 
 PLATFORMS ?= linux_amd64 linux_arm64

--- a/cluster/images/provider-grafana/Dockerfile
+++ b/cluster/images/provider-grafana/Dockerfile
@@ -8,41 +8,6 @@ ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/provider
 
 ENV USER_ID=65532
 
-# Setup Terraform environment
-
-## Provider-dependent configuration
-ARG TERRAFORM_VERSION
-ARG TERRAFORM_PROVIDER_SOURCE
-ARG TERRAFORM_PROVIDER_VERSION
-ARG TERRAFORM_PROVIDER_DOWNLOAD_NAME
-ARG TERRAFORM_NATIVE_PROVIDER_BINARY
-## End of - Provider-dependent configuration
-
-ENV PLUGIN_DIR /terraform/provider-mirror/registry.terraform.io/${TERRAFORM_PROVIDER_SOURCE}/${TERRAFORM_PROVIDER_VERSION}/${TARGETOS}_${TARGETARCH}
-ENV TF_CLI_CONFIG_FILE /terraform/.terraformrc
-ENV TF_FORK 0
-
-RUN mkdir -p ${PLUGIN_DIR}
-
-ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip /tmp
-ADD https://releases.hashicorp.com/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}/${TERRAFORM_PROVIDER_VERSION}/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_${TARGETOS}_${TARGETARCH}.zip /tmp
-ADD terraformrc.hcl ${TF_CLI_CONFIG_FILE}
-
-RUN unzip /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/local/bin \
-  && chmod +x /usr/local/bin/terraform \
-  && rm /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
-  && unzip /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d ${PLUGIN_DIR} \
-  && chmod +x ${PLUGIN_DIR}/* \
-  && rm /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
-  && chown -R ${USER_ID}:${USER_ID} /terraform
-# End of - Setup Terraform environment
-
-# Provider controller needs these environment variable at runtime
-ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}
-ENV TERRAFORM_PROVIDER_SOURCE ${TERRAFORM_PROVIDER_SOURCE}
-ENV TERRAFORM_PROVIDER_VERSION ${TERRAFORM_PROVIDER_VERSION}
-ENV TERRAFORM_NATIVE_PROVIDER_PATH ${PLUGIN_DIR}/${TERRAFORM_NATIVE_PROVIDER_BINARY}
-
 USER ${USER_ID}
 EXPOSE 8080
 

--- a/cluster/images/provider-grafana/Makefile
+++ b/cluster/images/provider-grafana/Makefile
@@ -23,15 +23,9 @@ img.publish:
 
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp terraformrc.hcl $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
 	@docker buildx build $(BUILD_ARGS) \
 		--platform $(IMAGE_PLATFORMS) \
-		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
-		--build-arg TERRAFORM_PROVIDER_SOURCE=$(TERRAFORM_PROVIDER_SOURCE) \
-		--build-arg TERRAFORM_PROVIDER_VERSION=$(TERRAFORM_PROVIDER_VERSION) \
-		--build-arg TERRAFORM_PROVIDER_DOWNLOAD_NAME=$(TERRAFORM_PROVIDER_DOWNLOAD_NAME) \
-		--build-arg TERRAFORM_NATIVE_PROVIDER_BINARY=$(TERRAFORM_NATIVE_PROVIDER_BINARY) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
 

--- a/cluster/images/provider-grafana/terraformrc.hcl
+++ b/cluster/images/provider-grafana/terraformrc.hcl
@@ -1,9 +1,0 @@
-provider_installation {
-  filesystem_mirror {
-    path    = "/terraform/provider-mirror"
-    include = ["*/*"]
-  }
-  direct {
-    exclude = ["*/*"]
-  }
-}


### PR DESCRIPTION
## Summary

- Remove terraform CLI and terraform-provider-grafana binary downloads from the Docker image
- Remove `terraformrc.hcl` and related build args from the image Makefile
- Remove unused `TERRAFORM_PROVIDER_DOWNLOAD_NAME`, `TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX`, and `TERRAFORM_NATIVE_PROVIDER_BINARY` variables from the root Makefile
- The provider uses the no-fork architecture (terraform-provider-grafana imported as a Go library), so these binaries are unused at runtime

## Motivation

The `RUN` steps that download and unzip terraform binaries add unnecessary weight to the Docker image, especially under QEMU for arm64. Removing them reduces image size and speeds up multi-arch image builds.

This matches the pattern used by [provider-upjet-aws](https://github.com/upbound/provider-upjet-aws), which also has no terraform binaries in its Docker image.

### Image size comparison

| | Old Dockerfile | New Dockerfile |
|---|---|---|
| Image size (per arch) | ~144 MB | ~36 MB |
| Total artifact size (both arches + xpkgs) | ~408 MB | ~198 MB |

~75% reduction in image size, ~51% reduction in total artifact size.

### `publish-artifacts` job timing

| Branch | Duration |
|---|---|
| Before (unmodified) | 10m 01s |
| After (this PR) | 9m 29s |

Note: the `publish-artifacts` job still runs sequentially after all other jobs. The modest timing improvement reflects the removal of terraform download/unzip steps under QEMU.

## Test plan

- [x] CI `local-deploy` job passes (builds xpkg, deploys to kind cluster, verifies provider health)
- [x] CI `publish-artifacts` job builds multi-arch images successfully
- [x] Compare `publish-artifacts` duration before/after