### PR TITLE
fix(generate): install goimports as part of generate.init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,9 +140,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports
-
       - name: Find the Go Build Cache
         id: go
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -108,9 +108,6 @@ jobs:
           go-version-file: go.mod
           cache: 'false'
 
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports
-
       - name: Vendor Dependencies
         run: make vendor vendor.check
 

--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,18 @@ pull-docs:
 	fi
 	@git -C "$(WORK_DIR)/$(TERRAFORM_PROVIDER_SOURCE)" sparse-checkout set "$(TERRAFORM_DOCS_PATH)"
 
-generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+GOIMPORTS := $(shell command -v goimports 2>/dev/null)
 
-.PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+install.goimports:
+ifndef GOIMPORTS
+	@$(INFO) installing goimports
+	@$(GO) install golang.org/x/tools/cmd/goimports@latest || $(FAIL)
+	@$(OK) installing goimports
+endif
+
+generate.init: install.goimports $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+
+.PHONY: install.goimports $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
 # ====================================================================================
 # Targets
 


### PR DESCRIPTION
## Summary
- Adds `install.goimports` target to the Makefile and wires it into `generate.init`
- Fixes Renovate `postUpgradeTask` failures where `make generate` panics because `goimports` is not available in the runner environment
- The target is a no-op if `goimports` is already installed

## Test plan
- [x] Verify `make generate` works on a clean environment without `goimports` pre-installed
- [x] Verify `make generate` still works when `goimports` is already available