### PR TITLE
fix(observed): persist and clear default external-name for data sources

### DIFF
--- a/pkg/tfdatasource/controller.go
+++ b/pkg/tfdatasource/controller.go
@@ -74,6 +74,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options, spec Spec) error {
 	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(spec.ManagedKind),
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), spec: spec}),
+		managed.WithInitializers(), // Disable the default NameAsExternalName initializer.
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithPollInterval(o.PollInterval),
@@ -121,22 +122,9 @@ type external struct {
 // reconciler calls Update, which is where the actual Read happens. This means
 // Observe effectively controls the poll interval: if IsUpToDate returns false
 // (or is nil, the default), the resource is re-read on every poll cycle.
-func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+func (e *external) Observe(_ context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
 	if meta.WasDeleted(mg) {
 		return managed.ExternalObservation{ResourceExists: false}, nil
-	}
-
-	// The managed reconciler defaults external-name to the K8s resource name.
-	// For observe-only resources this is wrong — the real external-name (e.g.
-	// the OnCall user/team ID) is only known after the data source Read in
-	// Update(). Clear the default so that reference resolvers using
-	// ExternalName() don't pick up a stale value before Update() runs.
-	obj := mg.(client.Object)
-	if meta.GetExternalName(mg) == obj.GetName() {
-		meta.SetExternalName(mg, "")
-		if err := e.kube.Update(ctx, obj); err != nil {
-			return managed.ExternalObservation{}, errors.Wrap(err, "cannot clear default external-name")
-		}
 	}
 
 	upToDate := false

--- a/pkg/tfdatasource/controller.go
+++ b/pkg/tfdatasource/controller.go
@@ -156,10 +156,18 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// The managed reconciler only persists annotation changes after Create(),
 	// not after Update(). Since observe-only resources never go through Create,
 	// we must persist annotation changes (specifically external-name) ourselves.
+	// Persist via a shallow copy so that the API server response (which lacks
+	// status for CRDs with a /status subresource) doesn't overwrite the
+	// AtProvider fields just set by Read on the original mg.
 	if meta.GetExternalName(mg) != extNameBefore {
-		if err := e.kube.Update(ctx, mg.(client.Object)); err != nil {
+		obj := mg.(client.Object)
+		copy := obj.DeepCopyObject().(client.Object)
+		if err := e.kube.Update(ctx, copy); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, "cannot persist external-name annotation")
 		}
+		// Sync the resource version from the persisted copy so that subsequent
+		// writes (e.g. status update by the reconciler) don't conflict.
+		obj.SetResourceVersion(copy.GetResourceVersion())
 	}
 
 	mg.(interface{ SetConditions(...xpv1.Condition) }).SetConditions(xpv1.Available())

--- a/pkg/tfdatasource/controller.go
+++ b/pkg/tfdatasource/controller.go
@@ -121,9 +121,22 @@ type external struct {
 // reconciler calls Update, which is where the actual Read happens. This means
 // Observe effectively controls the poll interval: if IsUpToDate returns false
 // (or is nil, the default), the resource is re-read on every poll cycle.
-func (e *external) Observe(_ context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
 	if meta.WasDeleted(mg) {
 		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+
+	// The managed reconciler defaults external-name to the K8s resource name.
+	// For observe-only resources this is wrong — the real external-name (e.g.
+	// the OnCall user/team ID) is only known after the data source Read in
+	// Update(). Clear the default so that reference resolvers using
+	// ExternalName() don't pick up a stale value before Update() runs.
+	obj := mg.(client.Object)
+	if meta.GetExternalName(mg) == obj.GetName() {
+		meta.SetExternalName(mg, "")
+		if err := e.kube.Update(ctx, obj); err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "cannot clear default external-name")
+		}
 	}
 
 	upToDate := false

--- a/pkg/tfdatasource/controller.go
+++ b/pkg/tfdatasource/controller.go
@@ -102,15 +102,16 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	meta, err := c.spec.ConnectFn(ctx, c.kube, mg)
+	providerMeta, err := c.spec.ConnectFn(ctx, c.kube, mg)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot connect to provider")
 	}
-	return &external{spec: c.spec, providerMeta: meta}, nil
+	return &external{kube: c.kube, spec: c.spec, providerMeta: providerMeta}, nil
 }
 
 // external implements managed.ExternalClient for observe-only resources.
 type external struct {
+	kube         client.Client
 	spec         Spec
 	providerMeta any
 }
@@ -146,9 +147,20 @@ func (e *external) Create(_ context.Context, _ resource.Managed) (managed.Extern
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	extNameBefore := meta.GetExternalName(mg)
 	if err := e.spec.Read(ctx, mg, e.providerMeta); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, "data source read failed")
 	}
+
+	// The managed reconciler only persists annotation changes after Create(),
+	// not after Update(). Since observe-only resources never go through Create,
+	// we must persist annotation changes (specifically external-name) ourselves.
+	if meta.GetExternalName(mg) != extNameBefore {
+		if err := e.kube.Update(ctx, mg.(client.Object)); err != nil {
+			return managed.ExternalUpdate{}, errors.Wrap(err, "cannot persist external-name annotation")
+		}
+	}
+
 	mg.(interface{ SetConditions(...xpv1.Condition) }).SetConditions(xpv1.Available())
 	tjresource.SetUpToDateCondition(mg, true)
 	return managed.ExternalUpdate{}, nil

--- a/pkg/tfdatasource/frameworkread.go
+++ b/pkg/tfdatasource/frameworkread.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	fwschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -58,6 +60,15 @@ func NewFrameworkReadFn(
 		}
 
 		fromState(ctx, mg, readResp.State)
+
+		// Set external-name from the Terraform "id" attribute in the state.
+		// The generated fromState callbacks don't do this for Framework data
+		// sources (unlike legacy SDK ones which call meta.SetExternalName).
+		var id string
+		if diags := readResp.State.GetAttribute(ctx, path.Root("id"), &id); !diags.HasError() && id != "" {
+			meta.SetExternalName(mg, id)
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- Fix Framework data source external-name not being persisted after Read
- Fix stale external-name causing incorrect reference resolution

## Provider bugfixes

### 1. Framework data source external-name

The generated `fromState` callbacks for Plugin Framework data sources don't call `meta.SetExternalName()` (unlike legacy SDK ones). This meant observed resources like oncall User would keep their K8s resource name as the external-name instead of the actual OnCall user ID, breaking all reference resolution that depends on `ExternalName()` extraction.

Two fixes were needed:
1. **`pkg/tfdatasource/frameworkread.go`**: Extract `id` from the Terraform state after `fromState()` and set it as `crossplane.io/external-name`
2. **`pkg/tfdatasource/controller.go`**: Persist the annotation via a direct API server update in `Update()`, because the crossplane-runtime v2 managed reconciler only persists annotations after `Create()`, not `Update()` — and observe-only resources never go through `Create`

Affects all 24 Framework-based observed resources (oncall User/UserSet/Label, k6, cloud, cloudprovider, fleetmanagement, frontendobservability, connections, oss).

### 2. Stale external-name default

When an observed resource is first created, the managed reconciler's default `NameAsExternalName` initializer sets `crossplane.io/external-name` to the K8s resource name. The reference resolver picks up this stale value via `ExternalName()` before `Update()` runs the actual data source Read and sets the real ID.

**Fix**: Disable the default `NameAsExternalName` initializer by passing an empty `managed.WithInitializers()` in the reconciler setup. This prevents the wrong default from being set in the first place, so external-name stays empty until `Update()` sets the real ID. This matches what all generated controllers in the project already do.

## Files changed

- **`pkg/tfdatasource/frameworkread.go`** — Extract `id` from Framework data source state, set as `crossplane.io/external-name`
- **`pkg/tfdatasource/controller.go`** — Pass kube client to external struct; persist external-name annotation in `Update()`; disable default `NameAsExternalName` initializer

## Test plan

- [x] `make generate` produces no diff
- [x] Verified via `make e2e-cloud` on the oncall-refs branch (which includes these fixes)