### PR TITLE
feat(ci): replace renovate postUpgradeTasks with GitHub Actions workflow

### DIFF
--- a/.github/actions/renovate-post-upgrade/README.md
+++ b/.github/actions/renovate-post-upgrade/README.md
@@ -1,0 +1,133 @@
+# Renovate Post-Upgrade Tasks
+
+A generic, language-agnostic composite action that detects which packages
+changed in a Renovate PR and runs corresponding post-upgrade commands. Results
+are committed and pushed back to the PR branch.
+
+> [!NOTE]
+> This action should probably live in
+> [grafana/shared-workflows](https://github.com/grafana/shared-workflows).
+
+## Inputs
+
+| Name       | Required | Description                                |
+|------------|----------|--------------------------------------------|
+| `rules`    | Yes      | JSON array of rule objects (see below)     |
+| `base-ref` | Yes      | Base branch to diff against (e.g. `main`) |
+
+### Rules format
+
+```json
+[
+  {
+    "packages": ["github.com/grafana/terraform-provider-grafana/v4"],
+    "commands": ["make submodules", "make generate"],
+    "files": ["go.mod"]
+  }
+]
+```
+
+Each rule must have all three fields:
+
+- **`packages`**: Package names to match in the diff. If any package appears in
+  the diff of the specified files, the rule matches.
+- **`commands`**: Commands to run when the rule matches.
+- **`files`**: Files to diff against the base branch for package detection.
+
+Multiple rules are supported. Commands are deduplicated across rules.
+
+## Outputs
+
+| Name           | Description                                      |
+|----------------|--------------------------------------------------|
+| `has-commands` | `true` if any rules matched, `false` otherwise   |
+| `commands`     | Newline-separated list of commands that were run  |
+
+## Prerequisites
+
+The action assumes:
+
+1. The repository is already checked out with `fetch-depth: 0` (full history
+   needed for diffing against the base branch).
+2. The checkout token has push permissions (so the commit can be pushed back).
+3. Any language-specific tooling needed by the commands is already set up
+   (e.g. Go, Node, Python).
+
+## Error handling
+
+- All steps use `set -euo pipefail` for strict error handling.
+- If a command fails, the job fails immediately. The "Commit and push" step is
+  skipped, so no broken state gets pushed.
+- The failure is visible on the PR as a failed check.
+
+## Example usage
+
+```yaml
+name: Renovate Post-Upgrade Tasks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  post-upgrade:
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Get GitHub App Token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.2.2
+        with:
+          github_app: your-app-name
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.get-github-token.outputs.token }}
+          fetch-depth: 0
+
+      # Set up any tooling your commands need
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run post-upgrade tasks
+        uses: ./.github/actions/renovate-post-upgrade
+        with:
+          base-ref: ${{ github.base_ref }}
+          rules: |
+            [
+              {
+                "packages": ["github.com/grafana/terraform-provider-grafana/v4"],
+                "commands": ["make submodules", "make generate"],
+                "files": ["go.mod"]
+              }
+            ]
+```
+
+### Node.js example
+
+```yaml
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: ./.github/actions/renovate-post-upgrade
+        with:
+          base-ref: ${{ github.base_ref }}
+          rules: |
+            [
+              {
+                "packages": ["@grafana/ui", "@grafana/data"],
+                "commands": ["npm run generate"],
+                "files": ["package.json"]
+              }
+            ]
+```

--- a/.github/actions/renovate-post-upgrade/action.yaml
+++ b/.github/actions/renovate-post-upgrade/action.yaml
@@ -1,0 +1,128 @@
+name: Renovate Post-Upgrade Tasks
+description: >
+  Detect which packages changed in a Renovate PR and run corresponding
+  post-upgrade commands. Commits and pushes the results back to the PR branch.
+
+inputs:
+  rules:
+    description: >
+      JSON array of rule objects. Each rule must have:
+        - packages: string[] — package names to match in the diff
+        - commands: string[] — commands to run when a package matches
+        - files:    string[] — files to diff against the base branch
+      Example:
+        [
+          {
+            "packages": ["github.com/grafana/terraform-provider-grafana/v4"],
+            "commands": ["make submodules", "make generate"],
+            "files": ["go.mod"]
+          }
+        ]
+    required: true
+
+  base-ref:
+    description: Base branch to diff against (e.g. "main")
+    required: true
+
+outputs:
+  has-commands:
+    description: Whether any rules matched and commands were run
+    value: ${{ steps.detect.outputs.has-commands }}
+  commands:
+    description: Newline-separated list of commands that were run
+    value: ${{ steps.detect.outputs.commands }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect updated packages
+      id: detect
+      shell: bash
+      env:
+        RULES: ${{ inputs.rules }}
+        BASE_REF: ${{ inputs.base-ref }}
+      run: |
+        commands=""
+
+        # Iterate over each rule in the JSON array
+        rule_count=$(echo "$RULES" | jq 'length')
+
+        for (( i=0; i<rule_count; i++ )); do
+          rule=$(echo "$RULES" | jq -c ".[$i]")
+
+          # Get the files to diff for this rule
+          files=$(echo "$rule" | jq -r '.files[]')
+
+          # Build the combined diff for all files in this rule
+          diff=""
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            file_diff=$(git diff "origin/${BASE_REF}...HEAD" -- "$file" 2>/dev/null || true)
+            diff="${diff}${file_diff}"$'\n'
+          done <<< "$files"
+
+          # Check if any package matches the diff
+          matched=false
+          packages=$(echo "$rule" | jq -r '.packages[]')
+          while IFS= read -r pkg; do
+            [ -z "$pkg" ] && continue
+            if echo "$diff" | grep -qF "$pkg"; then
+              echo "Matched package '$pkg' in rule $i"
+              matched=true
+              break
+            fi
+          done <<< "$packages"
+
+          if [ "$matched" = true ]; then
+            # Collect commands from this rule, deduplicating
+            rule_commands=$(echo "$rule" | jq -r '.commands[]')
+            while IFS= read -r cmd; do
+              [ -z "$cmd" ] && continue
+              if ! echo "$commands" | grep -qxF "$cmd"; then
+                commands="${commands}${cmd}"$'\n'
+              fi
+            done <<< "$rule_commands"
+          fi
+        done
+
+        # Trim trailing newline
+        commands=$(echo "$commands" | sed '/^$/d')
+
+        if [ -n "$commands" ]; then
+          echo "Commands to run:"
+          echo "$commands"
+          echo "has-commands=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "commands<<COMMANDS_EOF"
+            echo "$commands"
+            echo "COMMANDS_EOF"
+          } >> "$GITHUB_OUTPUT"
+        else
+          echo "No matching packages found"
+          echo "has-commands=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Run post-upgrade commands
+      if: steps.detect.outputs.has-commands == 'true'
+      shell: bash
+      run: |
+        while IFS= read -r cmd; do
+          [ -z "$cmd" ] && continue
+          echo "::group::Running: $cmd"
+          eval "$cmd"
+          echo "::endgroup::"
+        done <<< "${{ steps.detect.outputs.commands }}"
+
+    - name: Commit and push changes
+      if: steps.detect.outputs.has-commands == 'true'
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "chore: run post-upgrade tasks"
+          git push
+        fi

--- a/.github/actions/renovate-post-upgrade/action.yaml
+++ b/.github/actions/renovate-post-upgrade/action.yaml
@@ -42,6 +42,7 @@ runs:
         RULES: ${{ inputs.rules }}
         BASE_REF: ${{ inputs.base-ref }}
       run: |
+        set -euo pipefail
         commands=""
 
         # Iterate over each rule in the JSON array
@@ -106,6 +107,7 @@ runs:
       if: steps.detect.outputs.has-commands == 'true'
       shell: bash
       run: |
+        set -euo pipefail
         while IFS= read -r cmd; do
           [ -z "$cmd" ] && continue
           echo "::group::Running: $cmd"
@@ -117,6 +119,7 @@ runs:
       if: steps.detect.outputs.has-commands == 'true'
       shell: bash
       run: |
+        set -euo pipefail
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add -A

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -1,0 +1,139 @@
+name: Renovate Post-Upgrade Tasks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  post-upgrade:
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.user.login == 'renovate-sh-app[bot]'
+
+    permissions:
+      contents: read
+      id-token: write # needed for Vault OIDC
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Get GitHub App Token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.2.2
+        with:
+          github_app: TODO # fill in with the correct GitHub App name
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.get-github-token.outputs.token }}
+          submodules: true
+          fetch-depth: 0
+
+      - name: Detect updated packages in go.mod
+        id: detect
+        run: |
+          # Get the go.mod diff between the base branch and the PR
+          DIFF=$(git diff "origin/${{ github.base_ref }}...HEAD" -- go.mod || true)
+
+          # Define package groups and their corresponding make targets.
+          # Each rule mirrors a renovate packageRules entry:
+          #   PACKAGES_<rule>: newline-separated list of Go module paths to match
+          #   COMMANDS_<rule>: newline-separated list of make targets to run
+          PACKAGES_terraform_provider="
+            github.com/grafana/terraform-provider-grafana/v4
+          "
+          COMMANDS_terraform_provider="
+            make submodules
+            make generate
+          "
+
+          # Collect commands from all matching rules
+          commands=""
+
+          for rule in terraform_provider; do
+            packages_var="PACKAGES_${rule}"
+            commands_var="COMMANDS_${rule}"
+
+            while IFS= read -r pkg; do
+              pkg=$(echo "$pkg" | xargs) # trim whitespace
+              [ -z "$pkg" ] && continue
+              if echo "$DIFF" | grep -q "$pkg"; then
+                echo "Matched package '$pkg' in rule '$rule'"
+                while IFS= read -r cmd; do
+                  cmd=$(echo "$cmd" | xargs)
+                  [ -z "$cmd" ] && continue
+                  # Avoid duplicate commands
+                  if ! echo "$commands" | grep -qxF "$cmd"; then
+                    commands="${commands}${cmd}"$'\n'
+                  fi
+                done <<< "${!commands_var}"
+                break # One match per rule is sufficient
+              fi
+            done <<< "${!packages_var}"
+          done
+
+          if [ -n "$commands" ]; then
+            echo "Commands to run:"
+            echo "$commands"
+            echo "has-commands=true" >> "$GITHUB_OUTPUT"
+            # Write commands to a file for the next step
+            echo "$commands" > /tmp/post-upgrade-commands.txt
+          else
+            echo "No matching packages found in go.mod diff"
+            echo "has-commands=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Go
+        if: steps.detect.outputs.has-commands == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Find the Go Build Cache
+        if: steps.detect.outputs.has-commands == 'true'
+        id: go
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        if: steps.detect.outputs.has-commands == 'true'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-post-upgrade-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-post-upgrade-
+
+      - name: Cache Go Dependencies
+        if: steps.detect.outputs.has-commands == 'true'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Run post-upgrade tasks
+        if: steps.detect.outputs.has-commands == 'true'
+        run: |
+          while IFS= read -r cmd; do
+            cmd=$(echo "$cmd" | xargs)
+            [ -z "$cmd" ] && continue
+            echo "::group::Running: $cmd"
+            eval "$cmd"
+            echo "::endgroup::"
+          done < /tmp/post-upgrade-commands.txt
+
+      - name: Commit and push changes
+        if: steps.detect.outputs.has-commands == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: run post-upgrade tasks"
+            git push
+          fi

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -33,73 +33,16 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Detect updated packages in go.mod
-        id: detect
-        run: |
-          # Get the go.mod diff between the base branch and the PR
-          DIFF=$(git diff "origin/${{ github.base_ref }}...HEAD" -- go.mod || true)
-
-          # Define package groups and their corresponding make targets.
-          # Each rule mirrors a renovate packageRules entry:
-          #   PACKAGES_<rule>: newline-separated list of Go module paths to match
-          #   COMMANDS_<rule>: newline-separated list of make targets to run
-          PACKAGES_terraform_provider="
-            github.com/grafana/terraform-provider-grafana/v4
-          "
-          COMMANDS_terraform_provider="
-            make submodules
-            make generate
-          "
-
-          # Collect commands from all matching rules
-          commands=""
-
-          for rule in terraform_provider; do
-            packages_var="PACKAGES_${rule}"
-            commands_var="COMMANDS_${rule}"
-
-            while IFS= read -r pkg; do
-              pkg=$(echo "$pkg" | xargs) # trim whitespace
-              [ -z "$pkg" ] && continue
-              if echo "$DIFF" | grep -q "$pkg"; then
-                echo "Matched package '$pkg' in rule '$rule'"
-                while IFS= read -r cmd; do
-                  cmd=$(echo "$cmd" | xargs)
-                  [ -z "$cmd" ] && continue
-                  # Avoid duplicate commands
-                  if ! echo "$commands" | grep -qxF "$cmd"; then
-                    commands="${commands}${cmd}"$'\n'
-                  fi
-                done <<< "${!commands_var}"
-                break # One match per rule is sufficient
-              fi
-            done <<< "${!packages_var}"
-          done
-
-          if [ -n "$commands" ]; then
-            echo "Commands to run:"
-            echo "$commands"
-            echo "has-commands=true" >> "$GITHUB_OUTPUT"
-            # Write commands to a file for the next step
-            echo "$commands" > /tmp/post-upgrade-commands.txt
-          else
-            echo "No matching packages found in go.mod diff"
-            echo "has-commands=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup Go
-        if: steps.detect.outputs.has-commands == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Find the Go Build Cache
-        if: steps.detect.outputs.has-commands == 'true'
         id: go
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        if: steps.detect.outputs.has-commands == 'true'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -107,7 +50,6 @@ jobs:
           restore-keys: ${{ runner.os }}-build-post-upgrade-
 
       - name: Cache Go Dependencies
-        if: steps.detect.outputs.has-commands == 'true'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .work/pkg
@@ -115,25 +57,14 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Run post-upgrade tasks
-        if: steps.detect.outputs.has-commands == 'true'
-        run: |
-          while IFS= read -r cmd; do
-            cmd=$(echo "$cmd" | xargs)
-            [ -z "$cmd" ] && continue
-            echo "::group::Running: $cmd"
-            eval "$cmd"
-            echo "::endgroup::"
-          done < /tmp/post-upgrade-commands.txt
-
-      - name: Commit and push changes
-        if: steps.detect.outputs.has-commands == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: run post-upgrade tasks"
-            git push
-          fi
+        uses: ./.github/actions/renovate-post-upgrade
+        with:
+          base-ref: ${{ github.base_ref }}
+          rules: |
+            [
+              {
+                "packages": ["github.com/grafana/terraform-provider-grafana/v4"],
+                "commands": ["make submodules", "make generate"],
+                "files": ["go.mod"]
+              }
+            ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,21 +22,9 @@
         '/^sigs\\.k8s\\.io/controller-tools/',
       ],
     },
-    {
-      // When terraform-provider-grafana is updated, run make submodules and make generate
-      matchPackageNames: [
-        'github.com/grafana/terraform-provider-grafana/v4',
-      ],
-      postUpgradeTasks: {
-        commands: [
-          'make submodules',
-          'make generate',
-        ],
-        fileFilters: [
-          '**/*',
-        ],
-        executionMode: 'branch',
-      },
-    },
+    // Post-upgrade tasks for terraform-provider-grafana (and other packages)
+    // are handled by the renovate-post-upgrade.yaml workflow instead of
+    // postUpgradeTasks to avoid running commands in Renovate's permissive
+    // execution environment.
   ],
 }


### PR DESCRIPTION
## Summary

- Removes `postUpgradeTasks` from `renovate.json5` to eliminate running commands in Renovate's permissive execution environment (security risk)
- Adds a reusable composite action at `.github/actions/renovate-post-upgrade/` that detects which packages changed and runs matching commands
- Adds a workflow at `.github/workflows/renovate-post-upgrade.yaml` that uses the action on Renovate PRs
- Uses a GitHub App token to push commits back to the PR branch, which re-triggers CI

> [!NOTE]
> This action should probably be moved to [grafana/shared-workflows](https://github.com/grafana/shared-workflows) so other repositories can use it without referencing this repo. The action is already language-agnostic — it just needs `rules` JSON and a checked-out repo.

## Setup required

The workflow uses `grafana/shared-workflows/actions/create-github-app-token` to get a token with `contents:write` permission. Before merging, the following setup is needed:

### 1. Create or identify a GitHub App

You need a GitHub App installed on this repository with the following permissions:
- **Repository permissions > Contents**: Read and write

If a suitable app already exists in your org (check with your platform team), use that one.

### 2. Configure the app credentials in Vault

The `create-github-app-token` action retrieves the app credentials from Vault via GitHub OIDC. You need to:

1. Store the GitHub App's **App ID** and **Private Key** in Vault under the expected path for the app name
2. Ensure the Vault role allows OIDC authentication from this repository's workflows

Consult the [create-github-app-token action docs](https://github.com/grafana/shared-workflows/tree/main/actions/create-github-app-token) for the specific Vault path conventions and permission set configuration.

### 3. Update the workflow

Once the Vault setup is done, update the `TODO` placeholder in `.github/workflows/renovate-post-upgrade.yaml`:

```yaml
      - name: Get GitHub App Token
        id: get-github-token
        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.2.2
        with:
          github_app: TODO  # <-- replace with the actual app name
```

If the `default` permission set doesn't include `contents:write`, also add:

```yaml
          permission_set: <your-permission-set>
```

## Architecture

### Composite action (`.github/actions/renovate-post-upgrade/`)

A generic, language-agnostic action that:
1. Detects which packages changed by diffing specified files against the base branch
2. Runs matched commands (fails fast with `set -euo pipefail` — no partial results get committed)
3. Commits and pushes results

**Inputs:**
- `rules` (required): JSON array of rule objects, each with:
  - `packages`: `string[]` — package names to match in the diff
  - `commands`: `string[]` — commands to run when a package matches
  - `files`: `string[]` — files to diff against the base branch
- `base-ref` (required): base branch to diff against

**Outputs:**
- `has-commands`: whether any rules matched
- `commands`: newline-separated list of commands that were run

### Calling workflow (`.github/workflows/renovate-post-upgrade.yaml`)

Handles this repo's specific setup:
1. Triggers on Renovate bot PRs
2. Gets a GitHub App token via Vault OIDC
3. Checks out with the token (so pushes re-trigger CI)
4. Sets up Go and caching
5. Calls the composite action with the rules for this repo

### Usage from other repositories

```yaml
steps:
  # 1. Get a token that can push
  - uses: grafana/shared-workflows/actions/create-github-app-token@...
    id: token
    with:
      github_app: your-app-name

  # 2. Checkout with that token
  - uses: actions/checkout@...
    with:
      ref: ${{ github.head_ref }}
      token: ${{ steps.token.outputs.token }}
      fetch-depth: 0

  # 3. Any language-specific setup (Go, Node, Python, etc.)
  - uses: actions/setup-node@...

  # 4. Run the action
  - uses: grafana/crossplane-provider-grafana/.github/actions/renovate-post-upgrade@main
    with:
      base-ref: ${{ github.base_ref }}
      rules: |
        [
          {
            "packages": ["@grafana/ui"],
            "commands": ["npm run generate"],
            "files": ["package.json"]
          }
        ]
```

### Error handling

- All shell steps use `set -euo pipefail` for strict error handling
- If a command fails (e.g. `make generate`), the job fails immediately — the "Commit and push" step is skipped, so no broken state gets pushed
- The failure is visible on the PR as a failed check