### PR TITLE
chore(renovate): disable auto-updates for hashicorp/terraform-plugin-* packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,16 @@
       ],
     },
     {
+      // Disable auto-updates for hashicorp/terraform-plugin-* packages
+      // These are transitive dependencies that should update alongside terraform-provider-grafana
+      enabled: false,
+      matchPackageNames: [
+        '/^github\\.com/hashicorp/terraform-plugin-/',
+      ],
+    },
+    {
       // Terraform provider updates bring new/updated resources, use feat(deps) to trigger a minor release
+      // When terraform-provider-grafana is updated, run make submodules and make generate
       matchPackageNames: [
         'github.com/grafana/terraform-provider-grafana/v4',
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,21 +32,11 @@
     },
     {
       // Terraform provider updates bring new/updated resources, use feat(deps) to trigger a minor release
-      // When terraform-provider-grafana is updated, run make submodules and make generate
+      // When terraform-provider-grafana is updated, run make submodules and make generate on that PR
       matchPackageNames: [
         'github.com/grafana/terraform-provider-grafana/v4',
       ],
       semanticCommitType: 'feat',
-      postUpgradeTasks: {
-        commands: [
-          'make submodules',
-          'make generate',
-        ],
-        fileFilters: [
-          '**/*',
-        ],
-        executionMode: 'branch',
-      },
     },
     {
       // Other Go module updates affect the compiled binary, use fix(deps) to trigger a patch release


### PR DESCRIPTION
## Summary

- Disable Renovate auto-updates for `github.com/hashicorp/terraform-plugin-*` packages
- These are transitive dependencies that should update alongside `terraform-provider-grafana`, not independently

Supersedes #514, #513, #487.