### PR TITLE
fix: skip late-initialization of org_id to prevent API key auth failures

### DIFF
--- a/apis/cluster/alerting/v1alpha1/zz_contactpoint_terraformed.go
+++ b/apis/cluster/alerting/v1alpha1/zz_contactpoint_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ContactPoint) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/alerting/v1alpha1/zz_messagetemplate_terraformed.go
+++ b/apis/cluster/alerting/v1alpha1/zz_messagetemplate_terraformed.go
@@ -118,6 +118,7 @@ func (tr *MessageTemplate) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/alerting/v1alpha1/zz_mutetiming_terraformed.go
+++ b/apis/cluster/alerting/v1alpha1/zz_mutetiming_terraformed.go
@@ -118,6 +118,7 @@ func (tr *MuteTiming) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/alerting/v1alpha1/zz_notificationpolicy_terraformed.go
+++ b/apis/cluster/alerting/v1alpha1/zz_notificationpolicy_terraformed.go
@@ -118,6 +118,7 @@ func (tr *NotificationPolicy) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/alerting/v1alpha1/zz_rulegroup_terraformed.go
+++ b/apis/cluster/alerting/v1alpha1/zz_rulegroup_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RuleGroup) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/cloud/v1alpha1/zz_stack_terraformed.go
+++ b/apis/cluster/cloud/v1alpha1/zz_stack_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Stack) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_datasourcecacheconfig_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_datasourcecacheconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourceCacheConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_datasourcepermission_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_datasourcepermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourcePermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_datasourcepermissionitem_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_datasourcepermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourcePermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_report_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_report_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Report) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_role_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_role_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Role) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_roleassignment_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_roleassignment_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RoleAssignment) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_roleassignmentitem_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_roleassignmentitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RoleAssignmentItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/enterprise/v1alpha1/zz_scimconfig_terraformed.go
+++ b/apis/cluster/enterprise/v1alpha1/zz_scimconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ScimConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_annotation_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_annotation_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Annotation) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_dashboard_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_dashboard_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Dashboard) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_dashboardpermission_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_dashboardpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_dashboardpermissionitem_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_dashboardpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_dashboardpublic_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_dashboardpublic_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPublic) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_datasource_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_datasource_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSource) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_datasourceconfig_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_datasourceconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourceConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_folder_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_folder_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Folder) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_folderpermission_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_folderpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *FolderPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_folderpermissionitem_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_folderpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *FolderPermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_librarypanel_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_librarypanel_terraformed.go
@@ -118,6 +118,7 @@ func (tr *LibraryPanel) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_organization_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_organization_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Organization) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_organizationpreferences_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_organizationpreferences_terraformed.go
@@ -118,6 +118,7 @@ func (tr *OrganizationPreferences) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_playlist_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_playlist_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Playlist) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_serviceaccount_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_serviceaccount_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccount) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_serviceaccountpermission_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_serviceaccountpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccountPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_serviceaccountpermissionitem_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_serviceaccountpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccountPermissionItem) LateInitialize(attrs []byte) (bool, erro
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/oss/v1alpha1/zz_team_terraformed.go
+++ b/apis/cluster/oss/v1alpha1/zz_team_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Team) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/alerting/v1alpha1/zz_contactpoint_terraformed.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_contactpoint_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ContactPoint) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/alerting/v1alpha1/zz_messagetemplate_terraformed.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_messagetemplate_terraformed.go
@@ -118,6 +118,7 @@ func (tr *MessageTemplate) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/alerting/v1alpha1/zz_mutetiming_terraformed.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_mutetiming_terraformed.go
@@ -118,6 +118,7 @@ func (tr *MuteTiming) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/alerting/v1alpha1/zz_notificationpolicy_terraformed.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_notificationpolicy_terraformed.go
@@ -118,6 +118,7 @@ func (tr *NotificationPolicy) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/alerting/v1alpha1/zz_rulegroup_terraformed.go
+++ b/apis/namespaced/alerting/v1alpha1/zz_rulegroup_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RuleGroup) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/cloud/v1alpha1/zz_stack_terraformed.go
+++ b/apis/namespaced/cloud/v1alpha1/zz_stack_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Stack) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_datasourcecacheconfig_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_datasourcecacheconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourceCacheConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_datasourcepermission_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_datasourcepermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourcePermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_datasourcepermissionitem_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_datasourcepermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourcePermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_report_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_report_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Report) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_role_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_role_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Role) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_roleassignment_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_roleassignment_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RoleAssignment) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_roleassignmentitem_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_roleassignmentitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *RoleAssignmentItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/enterprise/v1alpha1/zz_scimconfig_terraformed.go
+++ b/apis/namespaced/enterprise/v1alpha1/zz_scimconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ScimConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_annotation_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_annotation_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Annotation) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_dashboard_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_dashboard_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Dashboard) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_dashboardpermission_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_dashboardpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_dashboardpermissionitem_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_dashboardpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_dashboardpublic_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_dashboardpublic_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DashboardPublic) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_datasource_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_datasource_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSource) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_datasourceconfig_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_datasourceconfig_terraformed.go
@@ -118,6 +118,7 @@ func (tr *DataSourceConfig) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_folder_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_folder_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Folder) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_folderpermission_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_folderpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *FolderPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_folderpermissionitem_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_folderpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *FolderPermissionItem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_librarypanel_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_librarypanel_terraformed.go
@@ -118,6 +118,7 @@ func (tr *LibraryPanel) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_organization_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_organization_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Organization) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_organizationpreferences_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_organizationpreferences_terraformed.go
@@ -118,6 +118,7 @@ func (tr *OrganizationPreferences) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_playlist_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_playlist_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Playlist) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_serviceaccount_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_serviceaccount_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccount) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_serviceaccountpermission_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_serviceaccountpermission_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccountPermission) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_serviceaccountpermissionitem_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_serviceaccountpermissionitem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ServiceAccountPermissionItem) LateInitialize(attrs []byte) (bool, erro
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/oss/v1alpha1/zz_team_terraformed.go
+++ b/apis/namespaced/oss/v1alpha1/zz_team_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Team) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("OrgID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -24,6 +24,24 @@ func ConfigureOrgIDRefs(p *ujconfig.Provider) {
 	}
 }
 
+// IgnoreOrgIDLateInit prevents upjet from late-initializing org_id on all
+// resources that have the field. The Grafana API always returns org_id in
+// responses, even when using API key auth. Without this, upjet's
+// late-initialization copies the value back into spec.forProvider, causing
+// subsequent reconciliations to fail with:
+//
+//	"org_id is only supported with basic auth. API keys are already org-scoped"
+func IgnoreOrgIDLateInit(p *ujconfig.Provider) {
+	for name, resource := range p.Resources {
+		if resource.TerraformResource.Schema["org_id"] == nil {
+			continue
+		}
+		p.AddResourceConfigurator(name, func(r *ujconfig.Resource) {
+			r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "org_id")
+		})
+	}
+}
+
 // Configure configures the grafana group
 func Configure(p *ujconfig.Provider) {
 	// configures all resources to be synced without async callbacks, the Grafana API is synchronous

--- a/config/provider.go
+++ b/config/provider.go
@@ -80,6 +80,7 @@ func GetProvider(generationProvider bool) (*ujconfig.Provider, error) {
 	return BuildProvider("grafana.crossplane.io", []func(provider *ujconfig.Provider){
 		// add custom config functions
 		grafana.ConfigureOrgIDRefs,
+		grafana.IgnoreOrgIDLateInit,
 		grafana.Configure,
 	}, generationProvider)
 }
@@ -89,6 +90,7 @@ func GetProviderNamespaced(generationProvider bool) (*ujconfig.Provider, error) 
 	return BuildProvider("grafana.m.crossplane.io", []func(provider *ujconfig.Provider){
 		// add custom config functions
 		grafana.ConfigureOrgIDRefs,
+		grafana.IgnoreOrgIDLateInit,
 		grafana.Configure,
 	}, generationProvider)
 }


### PR DESCRIPTION
## Summary

- Fix resources failing with `org_id is only supported with basic auth. API keys are already org-scoped` even when `orgId` is not set in the composition
- Add `IgnoreOrgIDLateInit` configurator that prevents upjet from late-initializing `org_id` on all resources that have the field

## Problem

```
Warning  CannotCreateExternalResource  75s (x12553 over 8d)  managed/alerting.grafana.crossplane.io/v1alpha1, kind=rulegroup  failed to create the resource: [{0 org_id is only supported with basic auth. API keys are already org-scoped  []}]
```

The Grafana API always returns `org_id` in responses, even when using API key auth. Upjet's late-initialization copies this value from `status.atProvider.orgId` back into `spec.forProvider.orgId`, making it appear as if the user set it. On subsequent reconciliations, the Terraform provider's validation rejects it because `org_id` is not supported with API key auth.

## Fix

A new `IgnoreOrgIDLateInit` function (following the same pattern as `ConfigureOrgIDRefs`) adds `org_id` to `LateInitializer.IgnoredFields` for all resources that have the field, preventing the feedback loop. This affects 64 generated `_terraformed.go` files across both cluster and namespaced variants.