### PR TITLE
ci: add git-cliff changelog, conventional commit enforcement, and release tooling

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,83 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+          scopes: |
+            [a-z][a-z0-9_-]*
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should not start with an uppercase character.
+
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        continue-on-error: true
+        with:
+          header: pr-title-lint-error
+          message: |
+            Pull request titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, because this repository uses squash merges and the PR title becomes the commit message.
+
+            **Format:** `<type>(<scope>): <subject>`
+
+            **Valid types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`
+
+            **Scope** is optional but recommended — use the affected resource name, e.g. `feat(dashboard): add uid attribute`.
+
+            **Subject** should be lowercase and use imperative mood (e.g. "add" not "added").
+
+            **Breaking changes:** append `!` after the type/scope, e.g. `feat(folder)!: rename uid to folder_uid`. Explain the breaking change in the PR description.
+
+            **Examples:**
+            - `feat(dashboard): add uid attribute`
+            - `fix(folder): handle missing parent on import`
+            - `feat(folder)!: rename uid to folder_uid`
+            - `chore: update Go dependencies`
+            - `docs: regenerate resource documentation`
+
+            See [contributing docs](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#pr-title-format) for full details.
+
+            <details><summary>Error details</summary>
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+            </details>
+
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        continue-on-error: true
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,12 +22,66 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+    - name: Unshallow
+      run: git fetch --prune --unshallow
+    - name: Generate changelog
+      id: changelog
+      uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
+      with:
+        args: --latest --strip header
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Compute expected version
+      id: expected_version
+      uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
+      with:
+        args: --bumped-version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Validate semver bump
+      env:
+        TAG_NAME: ${{ github.ref_name }}
+        EXPECTED_VERSION: ${{ steps.expected_version.outputs.content }}
+      run: |
+        # git-cliff computes the minimum required version based on conventional commits
+        expected="${EXPECTED_VERSION}"
+        actual="${TAG_NAME}"
+
+        echo "Minimum required version: $expected"
+        echo "Actual tag: $actual"
+
+        # Compare major.minor.patch — actual must be >= expected
+        IFS='.' read -r exp_major exp_minor exp_patch <<< "${expected#v}"
+        IFS='.' read -r act_major act_minor act_patch <<< "${actual#v}"
+
+        if [ "$act_major" -gt "$exp_major" ]; then
+          echo "Semver validation passed (major exceeds minimum)."
+          exit 0
+        elif [ "$act_major" -lt "$exp_major" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (major version too low)"
+          exit 1
+        fi
+
+        if [ "$act_minor" -gt "$exp_minor" ]; then
+          echo "Semver validation passed (minor exceeds minimum)."
+          exit 0
+        elif [ "$act_minor" -lt "$exp_minor" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (minor version too low)"
+          exit 1
+        fi
+
+        if [ "$act_patch" -lt "$exp_patch" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (patch version too low)"
+          exit 1
+        fi
+
+        echo "Semver validation passed."
     - run: ./hack/merge-crds.sh
     - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
       with:
         allowUpdates: true
         artifacts: "dist/*"
-        body: "See https://marketplace.upbound.io/providers/grafana/provider-grafana/ for API documentation."
+        bodyFile: ${{ steps.changelog.outputs.changelog }}
 
   deploy:
     name: Trigger Argo Workflow Deployment

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,14 @@ schema-version-diff:
 .PHONY: submodules fallthrough run crds.clean
 
 # ====================================================================================
+# Release
+
+release:
+	@./scripts/release.sh
+
+.PHONY: release
+
+# ====================================================================================
 # Special Targets
 
 define CROSSPLANE_MAKE_HELP

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,50 @@
+[changelog]
+header = ""
+body = """
+{% macro pr_link(commit) %}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/grafana/crossplane-provider-grafana/pull/{{ commit.remote.pr_number }})){% endif %}{% endmacro %}
+{% macro commit_line(commit) %}- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}{{ self::pr_link(commit=commit) }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% endmacro %}
+
+{% for group, group_commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in group_commits -%}
+{{ self::commit_line(commit=commit) }}
+{% endfor -%}
+{% endfor %}
+{% if previous.version %}
+**Full Changelog**: [{{ previous.version }}...{{ version }}](https://github.com/grafana/crossplane-provider-grafana/compare/{{ previous.version }}...{{ version }})
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+commit_preprocessors = [
+    { pattern = ' *\(#\d+\)', replace = "" },
+    { pattern = '\n.*', replace = "" },
+]
+filter_unconventional = false
+protect_breaking_commits = true
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { message = ".*", group = "Other Changes" },
+]
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+
+[remote.github]
+owner = "grafana"
+repo = "crossplane-provider-grafana"
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true
+custom_minor_increment_regex = "^(refactor|perf)"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 1. **Fork the repo** and create a branch from `main`.
 2. **Make your changes.** Follow the existing code style and patterns.
-3. **Run the linter** before opening a PR: `golangci-lint run ./... -v` (with the version from `.tool-versions`).
+3. **Run the linter** before opening a PR: `make lint`.
 4. **Open a pull request** against `main` — see [PR title format](#pr-title-format) below.
 
 ## PR title format

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,83 @@
 # Contributing
 
+## Submitting changes
+
+1. **Fork the repo** and create a branch from `main`.
+2. **Make your changes.** Follow the existing code style and patterns.
+3. **Run the linter** before opening a PR: `golangci-lint run ./... -v` (with the version from `.tool-versions`).
+4. **Open a pull request** against `main` — see [PR title format](#pr-title-format) below.
+
+## PR title format
+
+This repository uses **squash merges**, so all commits in a PR are combined
+into a single commit when merged. The **PR title becomes the commit message**,
+so it must follow the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+```
+<type>(<scope>): <subject>
+```
+
+A CI check validates the PR title and will block merging if it doesn't conform.
+
+### Types
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system or external dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance tasks, dependency updates, housekeeping |
+
+### Scope
+
+Scope is optional but recommended. Use the affected resource name when
+applicable. Scopes must be lowercase with no spaces.
+
+### Subject
+
+The subject should be lowercase, use imperative mood ("add" not "added"), and
+not end with a period.
+
+### Breaking changes
+
+Breaking changes should be avoided whenever possible. Crossplane users depend
+on stable CRD schemas, and breaking changes force manual migration of managed
+resources and compositions.
+
+When a breaking change is unavoidable, append `!` after the type (and scope, if
+present):
+
+```
+feat(folder)!: rename uid to folder_uid
+```
+
+Breaking changes must be explained in the PR description body. When squash
+merging, expand the commit message body to include a `BREAKING CHANGE:` footer
+describing what changed and how users should migrate. For example:
+
+```
+feat(folder)!: rename uid to folder_uid
+
+BREAKING CHANGE: The `uid` field on the Folder managed resource has been
+renamed to `folder_uid`. Update your compositions and claims accordingly.
+```
+
+### Examples
+
+- `feat(dashboard): add uid attribute`
+- `fix(folder): handle missing parent on import`
+- `refactor(team): simplify group mapping logic`
+- `feat(folder)!: rename uid to folder_uid`
+- `chore: update Go dependencies`
+- `docs: update contributing guide`
+
 ## Update resources
 
 Steps to update resources from the latest Terraform provider version:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,166 @@
+# Releasing
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+Version bumps are determined automatically from
+[conventional commit](https://www.conventionalcommits.org/) messages using
+[git-cliff](https://git-cliff.org).
+
+- **Major** (`vX.0.0`): Reserved for intentional breaking changes. Major
+  releases should be rare and well-documented with an upgrade guide. Examples:
+  - Removing or renaming existing managed resources
+  - Removing or renaming CRD fields
+  - Changing field types in incompatible ways
+  - Changing provider configuration in incompatible ways
+  - Any change that requires users to rewrite their compositions, claims, or
+    manually migrate managed resources
+
+- **Minor** (`vX.Y.0`): New features and improvements that are
+  backwards-compatible. **This is the most common release type.** Examples:
+  - Adding new managed resources
+  - Adding new optional fields to existing resources
+  - Upstream Terraform provider updates (these bring new/updated resources)
+  - Refactoring internals
+  - Performance improvements
+
+- **Patch** (`vX.Y.Z`): Backwards-compatible bug fixes and dependency updates.
+  These are typically follow-up releases after a minor release. Examples:
+  - Fixing incorrect API calls or state handling
+  - Fixing controller reconciliation logic
+  - Go dependency updates (security patches, bug fixes)
+  - Other small, targeted fixes
+
+### Bump rules
+
+The version bump is computed by git-cliff from the conventional commit messages
+since the last tag. The rules are configured in [`cliff.toml`](../cliff.toml)
+under the `[bump]` section.
+
+| Commit type(s) since last tag                             | Version bump          |
+|-----------------------------------------------------------|-----------------------|
+| Only `fix` (including `fix(deps)`)                        | **patch** (vX.Y.Z)   |
+| `feat`, `refactor`, or `perf` (with or without others)    | **minor** (vX.Y.0)   |
+| `BREAKING CHANGE` footer or `!` suffix on any commit type | **major** (vX.0.0)   |
+| Only `ci`, `docs`, `test`, `build`, `style`, `chore`      | No bump (nothing to release) |
+
+### Commit types and release impact
+
+| Commit type | Affects binary? | Triggers release? | Bump    |
+|-------------|-----------------|-------------------|---------|
+| `feat`      | yes             | yes               | minor   |
+| `fix`       | yes             | yes               | patch   |
+| `refactor`  | yes             | yes               | minor   |
+| `perf`      | yes             | yes               | minor   |
+| `docs`      | no              | no                | —       |
+| `ci`        | no              | no                | —       |
+| `test`      | no              | no                | —       |
+| `build`     | no              | no                | —       |
+| `style`     | no              | no                | —       |
+| `chore`     | no              | no                | —       |
+
+### Dependency updates
+
+Terraform provider updates (`github.com/grafana/terraform-provider-grafana`)
+are managed by Renovate and use `feat(deps)` as their commit type, because
+they bring new and updated upstream resources. These trigger a **minor**
+release.
+
+Other Go module dependency updates use `fix(deps)`, because changes to
+`go.mod`/`go.sum` affect the compiled provider binary. These trigger a
+**patch** release.
+
+GitHub Actions and other non-Go dependency updates use `chore(deps)` and do
+**not** trigger a release, since they have no effect on the shipped binary.
+
+This behavior is configured in [`renovate.json5`](../renovate.json5).
+
+## Creating a release
+
+### Prerequisites
+
+- [git-cliff](https://git-cliff.org/docs/installation) installed locally
+- Push access to the repository
+
+### Steps
+
+1. Switch to the `main` branch:
+
+   ```sh
+   git checkout main
+   ```
+
+2. Run the release target:
+
+   ```sh
+   make release
+   ```
+
+   The target will:
+   - Verify you are on `main` (refuses to run from other branches)
+   - Fetch from origin and prompt to pull if your local branch is behind
+   - Compute the next version from conventional commits using git-cliff
+
+   To override the computed version:
+
+   ```sh
+   RELEASE_VERSION=v3.0.0 make release
+   ```
+
+3. The tag push triggers the [`release`](../.github/workflows/release.yaml)
+   GitHub Actions workflow (see [CI pipeline](#ci-pipeline) below).
+
+4. Review the release on the
+   [Releases page](https://github.com/grafana/crossplane-provider-grafana/releases).
+
+### What `make release` does
+
+`make release` runs [`scripts/release.sh`](../scripts/release.sh), which
+performs the following checks and actions:
+
+```
+scripts/release.sh
+  │
+  ├─ on main branch?       → error if not
+  ├─ fetch origin/main
+  │   └─ local behind?     → prompt to pull (--ff-only)
+  │
+  ├─ RELEASE_VERSION set?  → use it
+  ├─ git-cliff installed?  → compute version via `git cliff --bumped-version`
+  │   └─ version == latest tag?  → error: nothing to release
+  └─ neither?              → error: install git-cliff or set RELEASE_VERSION
+  │
+  ├─ git tag <version>
+  └─ git push origin <version>
+```
+
+## CI pipeline
+
+The [`release.yaml`](../.github/workflows/release.yaml) workflow triggers on
+any tag push matching `v*`. It runs the following steps:
+
+1. **Generate changelog** — git-cliff produces release notes from conventional
+   commits since the previous tag (`--latest --strip header`).
+
+2. **Validate semver bump** — git-cliff computes the minimum required version
+   (`--bumped-version`) and compares it against the pushed tag. If the tag is
+   lower than what the commits require (e.g., tagging a patch when there are
+   `feat` commits), the workflow **fails** before building. This is a safety
+   net that catches incorrect manual overrides.
+
+3. **Merge CRDs** — combines individual CRD files for the release artifacts.
+
+4. **Create GitHub release** — creates a GitHub Release with the git-cliff
+   changelog as release notes and any artifacts from `dist/`.
+
+5. **Trigger deployment** — an Argo Workflow is triggered to deploy the new
+   version to the platform-monitoring infrastructure.
+
+### Configuration files
+
+| File                                                        | Purpose                                    |
+|-------------------------------------------------------------|--------------------------------------------|
+| [`scripts/release.sh`](../scripts/release.sh)               | Local release script (branch check, pull prompt, version computation, tag + push) |
+| [`cliff.toml`](../cliff.toml)                               | Changelog format, commit parsing, bump rules |
+| [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) | CI workflow that orchestrates the release |
+| [`renovate.json5`](../renovate.json5)                       | Renovate config for dependency update commit types |

--- a/renovate.json5
+++ b/renovate.json5
@@ -23,10 +23,11 @@
       ],
     },
     {
-      // When terraform-provider-grafana is updated, run make submodules and make generate
+      // Terraform provider updates bring new/updated resources, use feat(deps) to trigger a minor release
       matchPackageNames: [
         'github.com/grafana/terraform-provider-grafana/v4',
       ],
+      semanticCommitType: 'feat',
       postUpgradeTasks: {
         commands: [
           'make submodules',
@@ -37,6 +38,13 @@
         ],
         executionMode: 'branch',
       },
+    },
+    {
+      // Other Go module updates affect the compiled binary, use fix(deps) to trigger a patch release
+      matchManagers: [
+        'gomod',
+      ],
+      semanticCommitType: 'fix',
     },
   ],
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify we're on the main branch.
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+	echo "Error: releases must be created from the main branch (currently on '$branch')."
+	exit 1
+fi
+
+# Fetch latest state from origin.
+git fetch origin main --tags --quiet
+
+# Prompt to pull if local is behind.
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/main)
+if [ "$local_sha" != "$remote_sha" ]; then
+	echo "Local branch is behind origin/main."
+	printf "Pull latest changes? [y/N] "
+	read -r ans
+	if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
+		git pull --ff-only origin main
+	else
+		echo "Continuing with local HEAD."
+	fi
+fi
+
+# Determine the release version.
+if [ -n "${RELEASE_VERSION:-}" ]; then
+	echo "Using provided version: $RELEASE_VERSION"
+elif command -v git-cliff >/dev/null 2>&1; then
+	RELEASE_VERSION=$(git cliff --bumped-version 2>/dev/null)
+	latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
+	if [ "$RELEASE_VERSION" = "$latest_tag" ]; then
+		echo "Error: no unreleased changes to bump. Nothing to release."
+		exit 1
+	fi
+	echo "Computed version from conventional commits: $RELEASE_VERSION"
+else
+	echo "Error: git-cliff is not installed and RELEASE_VERSION is not set."
+	echo "Install git-cliff: https://git-cliff.org/docs/installation"
+	exit 1
+fi
+
+# Create and push the tag.
+# Use --no-sign to ensure a lightweight tag regardless of user's
+# tag.gpgSign config.
+git tag --no-sign "$RELEASE_VERSION"
+git push origin "$RELEASE_VERSION"


### PR DESCRIPTION
## Summary

- Add [git-cliff](https://git-cliff.org) for automated changelog generation and semantic version computation, matching the setup in [terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana)
- Enforce [conventional commit](https://www.conventionalcommits.org/) format on PR titles via a new CI check (`amannn/action-semantic-pull-request`)
- Update the release workflow to generate changelogs from conventional commits and validate semver bumps before creating the GitHub release
- Add a local release script (`make release`) that computes the next version and pushes a tag
- Configure Renovate to use `feat(deps)` for terraform-provider-grafana updates (minor bump) and `fix(deps)` for other Go module updates (patch bump)
- Document PR title format in `docs/contributing.md` and add `docs/releasing.md` covering versioning policy, bump rules, and the release process

## New files

| File | Purpose |
|------|---------|
| `cliff.toml` | git-cliff config: changelog template, commit parsing, bump rules, GitHub remote |
| `.github/workflows/pr-title.yml` | CI check enforcing conventional commit format on PR titles |
| `scripts/release.sh` | Local release script: branch check, version computation, tag + push |
| `docs/releasing.md` | Release process documentation |

## Modified files

| File | Change |
|------|--------|
| `.github/workflows/release.yaml` | Added git-cliff changelog generation, semver bump validation; release body now uses generated changelog |
| `Makefile` | Added `release` target |
| `renovate.json5` | Added `semanticCommitType` for terraform-provider-grafana (`feat`) and other Go modules (`fix`) |
| `docs/contributing.md` | Added PR title format section (conventional commits, types, scope, breaking changes) |