### PR TITLE
fix(generator): flatten NestingModeSingle blocks in generated examples

### DIFF
--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -67,7 +67,7 @@ func main() {
 func flattenObjectBlocks(pc *ujconfig.Provider, dir string) error {
 	kindPaths := collectObjectBlockPaths(pc)
 
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(filepath.Clean(dir), func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || !strings.HasSuffix(info.Name(), ".yaml") {
 			return err
 		}

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -5,11 +5,22 @@ Copyright 2021 Upbound Inc.
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
+	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/pipeline"
+	"github.com/crossplane/upjet/v2/pkg/schema/traverser"
+	"github.com/crossplane/upjet/v2/pkg/types/conversion/tfjson"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/grafana/crossplane-provider-grafana/v2/config"
 )
@@ -32,4 +43,175 @@ func main() {
 		panic(fmt.Sprintf("cannot get namespaced provider configuration: %s", err))
 	}
 	pipeline.Run(clusterProvider, namespacedProvider, absRootDir)
+
+	// Fix generated example manifests: NestingModeSingle Terraform blocks
+	// (SchemaTypeObject) are embedded objects in the CRD but the HCL-to-JSON
+	// scraper wraps them in arrays. Flatten them to plain objects.
+	//
+	// Note: upstream ApplyAPIConverters cannot handle SchemaTypeObject paths
+	// because they lack [*] wildcards that fieldpath needs to traverse into
+	// arrays. We process these ourselves by collecting the CRD paths via the
+	// schema traverser and flattening single-element arrays at those paths.
+	//
+	// See: https://github.com/grafana/crossplane-provider-grafana/issues/549
+	if err := flattenObjectBlocks(clusterProvider, filepath.Join(absRootDir, "examples-generated", "cluster")); err != nil {
+		panic(fmt.Sprintf("cannot flatten object blocks in cluster examples: %s", err))
+	}
+	if err := flattenObjectBlocks(namespacedProvider, filepath.Join(absRootDir, "examples-generated", "namespaced")); err != nil {
+		panic(fmt.Sprintf("cannot flatten object blocks in namespaced examples: %s", err))
+	}
+}
+
+// flattenObjectBlocks walks all YAML example files under dir and flattens
+// single-element arrays at SchemaTypeObject field paths to plain objects.
+func flattenObjectBlocks(pc *ujconfig.Provider, dir string) error {
+	kindPaths := collectObjectBlockPaths(pc)
+
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(info.Name(), ".yaml") {
+			return err
+		}
+		content, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+		if err != nil {
+			return errors.Wrapf(err, "read %s", path)
+		}
+
+		docs, err := decodeDocuments(content)
+		if err != nil {
+			return errors.Wrapf(err, "decode %s", path)
+		}
+		if len(docs) == 0 {
+			return nil
+		}
+
+		anyChanged := false
+		for _, obj := range docs {
+			kind, _ := obj["kind"].(string)
+			paths, ok := kindPaths[kind]
+			if !ok {
+				continue
+			}
+			for _, p := range paths {
+				if flattenPath(obj, strings.Split("spec.forProvider."+p, ".")) {
+					anyChanged = true
+				}
+			}
+		}
+		if !anyChanged {
+			return nil
+		}
+
+		if err := writeDocuments(path, docs); err != nil {
+			return errors.Wrapf(err, "write %s", path)
+		}
+		log.Printf("Flattened object blocks in: %s", path)
+		return nil
+	})
+}
+
+// collectObjectBlockPaths uses the upjet schema traverser to collect CRD
+// field paths for all SchemaTypeObject (NestingModeSingle) fields, keyed
+// by Kind.
+func collectObjectBlockPaths(pc *ujconfig.Provider) map[string][]string {
+	kindPaths := map[string][]string{}
+	for _, r := range pc.Resources {
+		c := &objectPathCollector{}
+		if err := ujconfig.TraverseSchemas(r.Name, r, c); err != nil {
+			log.Printf("WARN: failed to traverse schema for %s: %v", r.Name, err)
+			continue
+		}
+		if len(c.paths) > 0 {
+			kindPaths[r.Kind] = c.paths
+		}
+	}
+	return kindPaths
+}
+
+// objectPathCollector is a schema traverser that collects CRD paths for
+// SchemaTypeObject fields.
+type objectPathCollector struct {
+	paths []string
+	traverser.NoopTraverser
+}
+
+func (c *objectPathCollector) VisitResource(r *traverser.ResourceNode) error {
+	if r.Schema.Type != tfjson.SchemaTypeObject {
+		return nil
+	}
+	c.paths = append(c.paths, traverser.FieldPathWithWildcard(r.CRDPath))
+	return nil
+}
+
+// flattenPath descends the object following the path segments. At the last
+// segment, if the value is a single-element []interface{} containing a map,
+// it replaces it with that map. Returns true if a change was made.
+func flattenPath(obj map[string]interface{}, parts []string) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	key := parts[0]
+	val, ok := obj[key]
+	if !ok {
+		return false
+	}
+	if len(parts) == 1 {
+		if arr, ok := val.([]interface{}); ok && len(arr) == 1 {
+			if m, ok := arr[0].(map[string]interface{}); ok {
+				obj[key] = m
+				return true
+			}
+		}
+		return false
+	}
+	// Descend: handle both maps and single-element arrays (not yet flattened).
+	switch v := val.(type) {
+	case map[string]interface{}:
+		return flattenPath(v, parts[1:])
+	case []interface{}:
+		changed := false
+		for _, item := range v {
+			if m, ok := item.(map[string]interface{}); ok {
+				if flattenPath(m, parts[1:]) {
+					changed = true
+				}
+			}
+		}
+		return changed
+	}
+	return false
+}
+
+// decodeDocuments parses all YAML documents from content.
+func decodeDocuments(content []byte) ([]map[string]interface{}, error) {
+	var docs []map[string]interface{}
+	decoder := kyaml.NewYAMLOrJSONDecoder(bytes.NewReader(content), 4096)
+	for {
+		u := &unstructured.Unstructured{}
+		if err := decoder.Decode(u); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if u.Object != nil {
+			docs = append(docs, u.Object)
+		}
+	}
+	return docs, nil
+}
+
+// writeDocuments writes YAML documents back to the file, separated by "---".
+func writeDocuments(path string, docs []map[string]interface{}) error {
+	var buf bytes.Buffer
+	for i, doc := range docs {
+		out, err := yaml.Marshal(doc)
+		if err != nil {
+			return errors.Wrapf(err, "marshal document %d", i)
+		}
+		if i > 0 {
+			buf.WriteString("\n---\n\n")
+		}
+		buf.Write(out)
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o600)
 }

--- a/examples-generated/cluster/alerting/v1alpha1/alertenrichmentv1beta1.yaml
+++ b/examples-generated/cluster/alerting/v1alpha1/alertenrichmentv1beta1.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: test_enrichment
+      uid: test_enrichment
     spec:
-    - alertRuleUids:
+      alertRuleUids:
       - alert-rule-1
       - alert-rule-2
       annotationMatchers:

--- a/examples-generated/cluster/alerting/v1alpha1/alertrulev0alpha1.yaml
+++ b/examples-generated/cluster/alerting/v1alpha1/alertrulev0alpha1.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - folderUid: ${grafana_folder.alertrule_folder.uid}
+      folderUid: ${grafana_folder.alertrule_folder.uid}
       uid: example-alert-rule
     spec:
-    - annotations:
+      annotations:
         runbook_url: https://example.com
       execErrState: KeepLast
       expressions:
@@ -82,15 +82,15 @@ spec:
       missingSeriesEvalsToResolve: 5
       noDataState: KeepLast
       notificationSettings:
-      - simplifiedRouting:
-        - contactPoint: grafana-default-email
+        simplifiedRouting:
+          contactPoint: grafana-default-email
       panelRef:
         dashboard_uid: dashboard123
         panel_id: "5"
       paused: true
       title: Example Alert Rule
       trigger:
-      - interval: 1m
+        interval: 1m
 
 ---
 

--- a/examples-generated/cluster/alerting/v1alpha1/recordingrulev0alpha1.yaml
+++ b/examples-generated/cluster/alerting/v1alpha1/recordingrulev0alpha1.yaml
@@ -9,11 +9,11 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - folderUid: ${grafana_folder.recordingrule_folder.uid}
+      folderUid: ${grafana_folder.recordingrule_folder.uid}
       uid: example-recording-rule
     provider: ${grafana.local}
     spec:
-    - expressions:
+      expressions:
         A: |-
           ${jsonencode({
                   model = {
@@ -41,7 +41,7 @@ spec:
       targetDatasourceUid: target_ds_uid
       title: Example Recording Rule
       trigger:
-      - interval: 1m
+        interval: 1m
 
 ---
 

--- a/examples-generated/cluster/cloud/v1alpha1/appo11yconfigv1alpha1.yaml
+++ b/examples-generated/cluster/cloud/v1alpha1/appo11yconfigv1alpha1.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/cluster/cloud/v1alpha1/dbo11yconfigv1alpha1.yaml
+++ b/examples-generated/cluster/cloud/v1alpha1/dbo11yconfigv1alpha1.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/cluster/cloud/v1alpha1/k8so11yconfigv1alpha1.yaml
+++ b/examples-generated/cluster/cloud/v1alpha1/k8so11yconfigv1alpha1.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/cluster/k6/v1alpha1/schedule.yaml
+++ b/examples-generated/cluster/k6/v1alpha1/schedule.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   forProvider:
     cron:
-    - schedule: 0 10 1 * *
+      schedule: 0 10 1 * *
       timezone: UTC
     loadTestId: ${grafana_k6_load_test.scheduled_test.id}
     starts: "2024-12-25T10:00:00Z"

--- a/examples-generated/cluster/oss/v1alpha1/connectionv0alpha1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/connectionv0alpha1.yaml
@@ -9,15 +9,15 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: my-github-connection
+      uid: my-github-connection
     secure:
-    - privateKey:
+      privateKey:
         create: ${filebase64("${path.module}/private-key.pem")}
     secureVersion: 1
     spec:
-    - description: GitHub App connection used by a folder-scoped Git Sync repository
+      description: GitHub App connection used by a folder-scoped Git Sync repository
       github:
-      - appId: "12345"
+        appId: "12345"
         installationId: "67890"
       title: My GitHub App Connection
       type: github

--- a/examples-generated/cluster/oss/v1alpha1/dashboardv1beta1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/dashboardv1beta1.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard
+      uid: example-dashboard
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title         = "Example Dashboard"
               uid           = "example-dashboard"

--- a/examples-generated/cluster/oss/v1alpha1/dashboardv2.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/dashboardv2.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard-v2
+      uid: example-dashboard-v2
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title       = "Example Dashboard V2"
               cursorSync  = "Off"

--- a/examples-generated/cluster/oss/v1alpha1/dashboardv2beta1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/dashboardv2beta1.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard-v2
+      uid: example-dashboard-v2
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title       = "Example Dashboard V2"
               cursorSync  = "Off"

--- a/examples-generated/cluster/oss/v1alpha1/playlistv0alpha1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/playlistv0alpha1.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-playlist
+      uid: example-playlist
     spec:
-    - interval: 5m
+      interval: 5m
       items:
       - type: dashboard_by_uid
         value: example-dashboard

--- a/examples-generated/cluster/oss/v1alpha1/playlistv1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/playlistv1.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-playlist
+      uid: example-playlist
     spec:
-    - interval: 5m
+      interval: 5m
       items:
       - type: dashboard_by_uid
         value: example-dashboard

--- a/examples-generated/cluster/oss/v1alpha1/repositoryv0alpha1.yaml
+++ b/examples-generated/cluster/oss/v1alpha1/repositoryv0alpha1.yaml
@@ -9,25 +9,25 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: my-github-folder-repo
+      uid: my-github-folder-repo
     secure:
-    - token:
+      token:
         create: replace-me
     secureVersion: 1
     spec:
-    - description: Folder-scoped GitHub repository authenticated directly with a token
+      description: Folder-scoped GitHub repository authenticated directly with a token
       github:
-      - branch: main
+        branch: main
         path: grafanatftest
         url: https://github.com/example/grafana-dashboards
       sync:
-      - enabled: true
+        enabled: true
         intervalSeconds: 60
         target: folder
       title: My GitHub Folder Repository
       type: github
       webhook:
-      - baseUrl: https://grafana.example.com
+        baseUrl: https://grafana.example.com
       workflows:
       - write
       - branch

--- a/examples-generated/namespaced/alerting/v1alpha1/alertenrichmentv1beta1.yaml
+++ b/examples-generated/namespaced/alerting/v1alpha1/alertenrichmentv1beta1.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: test_enrichment
+      uid: test_enrichment
     spec:
-    - alertRuleUids:
+      alertRuleUids:
       - alert-rule-1
       - alert-rule-2
       annotationMatchers:

--- a/examples-generated/namespaced/alerting/v1alpha1/alertrulev0alpha1.yaml
+++ b/examples-generated/namespaced/alerting/v1alpha1/alertrulev0alpha1.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - folderUid: ${grafana_folder.alertrule_folder.uid}
+      folderUid: ${grafana_folder.alertrule_folder.uid}
       uid: example-alert-rule
     spec:
-    - annotations:
+      annotations:
         runbook_url: https://example.com
       execErrState: KeepLast
       expressions:
@@ -83,15 +83,15 @@ spec:
       missingSeriesEvalsToResolve: 5
       noDataState: KeepLast
       notificationSettings:
-      - simplifiedRouting:
-        - contactPoint: grafana-default-email
+        simplifiedRouting:
+          contactPoint: grafana-default-email
       panelRef:
         dashboard_uid: dashboard123
         panel_id: "5"
       paused: true
       title: Example Alert Rule
       trigger:
-      - interval: 1m
+        interval: 1m
 
 ---
 

--- a/examples-generated/namespaced/alerting/v1alpha1/recordingrulev0alpha1.yaml
+++ b/examples-generated/namespaced/alerting/v1alpha1/recordingrulev0alpha1.yaml
@@ -10,11 +10,11 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - folderUid: ${grafana_folder.recordingrule_folder.uid}
+      folderUid: ${grafana_folder.recordingrule_folder.uid}
       uid: example-recording-rule
     provider: ${grafana.local}
     spec:
-    - expressions:
+      expressions:
         A: |-
           ${jsonencode({
                   model = {
@@ -42,7 +42,7 @@ spec:
       targetDatasourceUid: target_ds_uid
       title: Example Recording Rule
       trigger:
-      - interval: 1m
+        interval: 1m
 
 ---
 

--- a/examples-generated/namespaced/cloud/v1alpha1/appo11yconfigv1alpha1.yaml
+++ b/examples-generated/namespaced/cloud/v1alpha1/appo11yconfigv1alpha1.yaml
@@ -10,6 +10,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/namespaced/cloud/v1alpha1/dbo11yconfigv1alpha1.yaml
+++ b/examples-generated/namespaced/cloud/v1alpha1/dbo11yconfigv1alpha1.yaml
@@ -10,6 +10,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/namespaced/cloud/v1alpha1/k8so11yconfigv1alpha1.yaml
+++ b/examples-generated/namespaced/cloud/v1alpha1/k8so11yconfigv1alpha1.yaml
@@ -10,6 +10,6 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: global
+      uid: global
     spec:
-    - enabled: true
+      enabled: true

--- a/examples-generated/namespaced/k6/v1alpha1/schedule.yaml
+++ b/examples-generated/namespaced/k6/v1alpha1/schedule.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   forProvider:
     cron:
-    - schedule: 0 10 1 * *
+      schedule: 0 10 1 * *
       timezone: UTC
     loadTestId: ${grafana_k6_load_test.scheduled_test.id}
     starts: "2024-12-25T10:00:00Z"

--- a/examples-generated/namespaced/oss/v1alpha1/connectionv0alpha1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/connectionv0alpha1.yaml
@@ -10,15 +10,15 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: my-github-connection
+      uid: my-github-connection
     secure:
-    - privateKey:
+      privateKey:
         create: ${filebase64("${path.module}/private-key.pem")}
     secureVersion: 1
     spec:
-    - description: GitHub App connection used by a folder-scoped Git Sync repository
+      description: GitHub App connection used by a folder-scoped Git Sync repository
       github:
-      - appId: "12345"
+        appId: "12345"
         installationId: "67890"
       title: My GitHub App Connection
       type: github

--- a/examples-generated/namespaced/oss/v1alpha1/dashboardv1beta1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/dashboardv1beta1.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard
+      uid: example-dashboard
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title         = "Example Dashboard"
               uid           = "example-dashboard"

--- a/examples-generated/namespaced/oss/v1alpha1/dashboardv2.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/dashboardv2.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard-v2
+      uid: example-dashboard-v2
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title       = "Example Dashboard V2"
               cursorSync  = "Off"

--- a/examples-generated/namespaced/oss/v1alpha1/dashboardv2beta1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/dashboardv2beta1.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-dashboard-v2
+      uid: example-dashboard-v2
     spec:
-    - json: |-
+      json: |-
         ${jsonencode({
               title       = "Example Dashboard V2"
               cursorSync  = "Off"

--- a/examples-generated/namespaced/oss/v1alpha1/playlistv0alpha1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/playlistv0alpha1.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-playlist
+      uid: example-playlist
     spec:
-    - interval: 5m
+      interval: 5m
       items:
       - type: dashboard_by_uid
         value: example-dashboard

--- a/examples-generated/namespaced/oss/v1alpha1/playlistv1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/playlistv1.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: example-playlist
+      uid: example-playlist
     spec:
-    - interval: 5m
+      interval: 5m
       items:
       - type: dashboard_by_uid
         value: example-dashboard

--- a/examples-generated/namespaced/oss/v1alpha1/repositoryv0alpha1.yaml
+++ b/examples-generated/namespaced/oss/v1alpha1/repositoryv0alpha1.yaml
@@ -10,25 +10,25 @@ metadata:
 spec:
   forProvider:
     metadata:
-    - uid: my-github-folder-repo
+      uid: my-github-folder-repo
     secure:
-    - token:
+      token:
         create: replace-me
     secureVersion: 1
     spec:
-    - description: Folder-scoped GitHub repository authenticated directly with a token
+      description: Folder-scoped GitHub repository authenticated directly with a token
       github:
-      - branch: main
+        branch: main
         path: grafanatftest
         url: https://github.com/example/grafana-dashboards
       sync:
-      - enabled: true
+        enabled: true
         intervalSeconds: 60
         target: folder
       title: My GitHub Folder Repository
       type: github
       webhook:
-      - baseUrl: https://grafana.example.com
+        baseUrl: https://grafana.example.com
       workflows:
       - write
       - branch


### PR DESCRIPTION
## Summary

- Adds a post-processing step to `cmd/generator/main.go` that flattens single-element arrays at `SchemaTypeObject` (NestingModeSingle) field paths to plain objects in generated example YAML files
- Fixes 29 generated example manifests (cluster + namespaced) that had array syntax (`- field: value`) where the CRD expects plain objects (`field: value`), causing "unknown field" errors on apply

## Background

The HCL-to-JSON scraper in upjet always wraps Terraform blocks in arrays (per HCL spec). For `NestingModeSingle` blocks, upjet maps these to `SchemaTypeObject` and generates CRD types as embedded objects (pointer-to-struct), not slices. However, the generated example manifests retained the array syntax from the scraper.

Upstream `ApplyAPIConverters` only handles `TypeList`/`TypeSet` with `MaxItems=1`, not `SchemaTypeObject` fields. This is the first upjet-based provider to hit this gap because the Grafana Terraform provider uses the newer plugin framework `NestingModeSingle` pattern instead of the older `TypeList + MaxItems=1` pattern used by AWS/GCP/Azure providers.

## Implementation

Uses upjet's schema traverser to collect CRD paths for `SchemaTypeObject` fields per Kind, then walks all generated example YAML files and flattens single-element arrays at those paths. Handles multi-document YAML correctly (e.g., k6 schedule with 3 documents).

Fixes #549