### PR TITLE
fix(team): treat ReadTeam ID parse error as resource-not-found

### DIFF
--- a/config/grafana/oss.go
+++ b/config/grafana/oss.go
@@ -7,8 +7,10 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
 func configureOSS(p *ujconfig.Provider) {
@@ -135,6 +137,23 @@ func configureOSS(p *ujconfig.Provider) {
 			RefFieldName:      "MemberRefs",
 			SelectorFieldName: "MemberSelector",
 			Extractor:         fieldExtractor("email"),
+		}
+		// On first reconcile the crossplane.io/external-name annotation is
+		// empty, so terraform-provider-grafana's ReadTeam parses an empty
+		// "[orgID:]teamID" composite ID and surfaces a fatal diagnostic
+		// instead of returning not-found. Match that specific diagnostic
+		// and treat it as resource-not-found so upjet triggers Create.
+		// See https://github.com/grafana/crossplane-provider-grafana/issues/562.
+		r.ExternalName.IsNotFoundDiagnosticFn = func(diags []*tfprotov6.Diagnostic) bool {
+			for _, d := range diags {
+				if d == nil || d.Severity != tfprotov6.DiagnosticSeverityError {
+					continue
+				}
+				if strings.Contains(d.Detail, `Failed to parse resource ID: expected int for field "id"`) {
+					return true
+				}
+			}
+			return false
 		}
 	})
 	p.AddResourceConfigurator(


### PR DESCRIPTION
On first reconcile of an oss.grafana[.m].crossplane.io/v1alpha1 Team, the crossplane.io/external-name annotation is empty. Upjet's plugin-framework Observe calls terraform-provider-grafana's ReadTeam with an empty ID, which fails the strict "[orgID:]teamID" parse and returns a fatal diagnostic instead of "not found". Upjet then surfaces this as a reconcile error, blocking Create from ever running:

    observe failed: read resource request failed:
    Failed to parse resource ID: expected int for field "id", got ""

Wire IsNotFoundDiagnosticFn on the grafana_team resource so that this specific diagnostic is treated as resource-not-found, letting upjet proceed to Create. After Create populates external-name with the real team ID, subsequent reconciles take the normal happy path and this matcher never fires.

Scoped narrowly to the exact diagnostic detail substring so it cannot mask unrelated read failures.

Fixes #562
