### PR TITLE
feat(ci): add cosign keyless signing for published packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,6 +380,12 @@ jobs:
       - name: Install Crossplane CLI
         run: make build.init
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+
       - name: Get Upbound Credentials from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
@@ -402,6 +408,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine package version
+        id: version
+        run: echo "version=$(git describe --dirty --always --tags | sed 's|.*/||; s/-/./2; s/-/./2; s/-/./2')" >> "$GITHUB_OUTPUT"
+
       - name: Publish Artifacts to Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}
@@ -409,8 +419,19 @@ jobs:
           REGISTRY_ORGS: xpkg.upbound.io/grafana
           XPKG_REG_ORGS: xpkg.upbound.io/grafana
 
+      - name: Sign package on Upbound
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
+        run: |
+          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}")
+          cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
+
       - name: Publish Artifacts to GHCR
         run: make publish BRANCH_NAME=${GITHUB_REF##*/} RELEASE_BRANCH_FILTER="%"
         env:
           REGISTRY_ORGS: ghcr.io/${{ github.repository_owner }}
           XPKG_REG_ORGS: ghcr.io/${{ github.repository_owner }}
+
+      - name: Sign package on GHCR
+        run: |
+          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}")
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -386,6 +386,9 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Get Upbound Credentials from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
@@ -419,11 +422,14 @@ jobs:
           REGISTRY_ORGS: xpkg.upbound.io/grafana
           XPKG_REG_ORGS: xpkg.upbound.io/grafana
 
-      - name: Sign package on Upbound
+      - name: Sign and attest package on Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: |
-          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
-          cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
+          REF="xpkg.upbound.io/grafana/provider-grafana"
+          DIGEST=$(crane digest "${REF}:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
+          cosign sign --yes "${REF}@${DIGEST}"
+          syft "${REF}@${DIGEST}" -o spdx-json=sbom.spdx.json
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REF}@${DIGEST}"
 
       - name: Publish Artifacts to GHCR
         run: make publish BRANCH_NAME=${GITHUB_REF##*/} RELEASE_BRANCH_FILTER="%"
@@ -431,7 +437,10 @@ jobs:
           REGISTRY_ORGS: ghcr.io/${{ github.repository_owner }}
           XPKG_REG_ORGS: ghcr.io/${{ github.repository_owner }}
 
-      - name: Sign package on GHCR
+      - name: Sign and attest package on GHCR
         run: |
-          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
-          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"
+          REF="ghcr.io/${{ github.repository_owner }}/provider-grafana"
+          DIGEST=$(crane digest "${REF}:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
+          cosign sign --yes "${REF}@${DIGEST}"
+          syft "${REF}@${DIGEST}" -o spdx-json=sbom.spdx.json
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REF}@${DIGEST}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -422,7 +422,7 @@ jobs:
       - name: Sign package on Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: |
-          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}")
+          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
           cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
 
       - name: Publish Artifacts to GHCR
@@ -433,5 +433,5 @@ jobs:
 
       - name: Sign package on GHCR
         run: |
-          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}")
+          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
           cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -273,7 +273,7 @@ jobs:
       - name: Sign package on Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: |
-          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}")
+          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
           cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
 
       - name: Publish Artifacts to GHCR
@@ -284,5 +284,5 @@ jobs:
 
       - name: Sign package on GHCR
         run: |
-          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}")
+          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
           cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -243,6 +243,9 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
@@ -270,11 +273,14 @@ jobs:
           REGISTRY_ORGS: xpkg.upbound.io/grafana
           XPKG_REG_ORGS: xpkg.upbound.io/grafana
 
-      - name: Sign package on Upbound
+      - name: Sign and attest package on Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: |
-          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
-          cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
+          REF="xpkg.upbound.io/grafana/provider-grafana"
+          DIGEST=$(crane digest "${REF}:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
+          cosign sign --yes "${REF}@${DIGEST}"
+          syft "${REF}@${DIGEST}" -o spdx-json=sbom.spdx.json
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REF}@${DIGEST}"
 
       - name: Publish Artifacts to GHCR
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}
@@ -282,7 +288,10 @@ jobs:
           REGISTRY_ORGS: ghcr.io/${{ github.repository_owner }}
           XPKG_REG_ORGS: ghcr.io/${{ github.repository_owner }}
 
-      - name: Sign package on GHCR
+      - name: Sign and attest package on GHCR
         run: |
-          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
-          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"
+          REF="ghcr.io/${{ github.repository_owner }}/provider-grafana"
+          DIGEST=$(crane digest "${REF}:${{ steps.version.outputs.version }}" 2>/dev/null) || { echo "Package not found, skipping signing"; exit 0; }
+          cosign sign --yes "${REF}@${DIGEST}"
+          syft "${REF}@${DIGEST}" -o spdx-json=sbom.spdx.json
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REF}@${DIGEST}"

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -237,6 +237,12 @@ jobs:
           go-version-file: go.mod
           cache: 'false'
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
@@ -253,6 +259,10 @@ jobs:
           name: output
           path: _output/**
 
+      - name: Determine package version
+        id: version
+        run: echo "version=$(git describe --dirty --always --tags | sed 's|.*/||; s/-/./2; s/-/./2; s/-/./2')" >> "$GITHUB_OUTPUT"
+
       - name: Publish Artifacts to Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}
@@ -260,8 +270,19 @@ jobs:
           REGISTRY_ORGS: xpkg.upbound.io/grafana
           XPKG_REG_ORGS: xpkg.upbound.io/grafana
 
+      - name: Sign package on Upbound
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_ID != ''
+        run: |
+          DIGEST=$(crane digest "xpkg.upbound.io/grafana/provider-grafana:${{ steps.version.outputs.version }}")
+          cosign sign --yes "xpkg.upbound.io/grafana/provider-grafana@${DIGEST}"
+
       - name: Publish Artifacts to GHCR
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}
         env:
           REGISTRY_ORGS: ghcr.io/${{ github.repository_owner }}
           XPKG_REG_ORGS: ghcr.io/${{ github.repository_owner }}
+
+      - name: Sign package on GHCR
+        run: |
+          DIGEST=$(crane digest "ghcr.io/${{ github.repository_owner }}/provider-grafana:${{ steps.version.outputs.version }}")
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/provider-grafana@${DIGEST}"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,52 @@ You can see the API reference [here](https://marketplace.upbound.io/providers/gr
 
 For information on configuring provider credentials and ProviderConfig secret fields, see the [ProviderConfig Secret Fields documentation](docs/providerconfig-secret-fields.md).
 
+## Signature Verification
+
+Published packages are cryptographically signed using [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing with GitHub Actions OIDC. This lets you verify that a package was built by this repository's CI pipeline and hasn't been tampered with.
+
+### Verify a package signature
+
+```bash
+cosign verify \
+  ghcr.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+The same works for packages on the Upbound Marketplace:
+
+```bash
+cosign verify \
+  xpkg.upbound.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+### Automatic verification in Crossplane
+
+Crossplane 1.18+ supports automatic signature verification on package install via [ImageConfig](https://docs.crossplane.io/latest/packages/image-configs/#configuring-signature-verification):
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: verify-provider-grafana
+spec:
+  matchImages:
+    - prefix: "ghcr.io/grafana/provider-grafana:"
+    - prefix: "xpkg.upbound.io/grafana/provider-grafana:"
+  verification:
+    provider: Cosign
+    cosign:
+      authorities:
+        - name: grafana-ci
+          keyless:
+            identities:
+              - issuer: https://token.actions.githubusercontent.com
+                subjectRegExp: https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*
+```
+
 ## Contributing
 
 See [docs/contributing.md](docs/contributing.md) for development setup and contribution guidelines.

--- a/README.md
+++ b/README.md
@@ -39,49 +39,7 @@ For information on configuring provider credentials and ProviderConfig secret fi
 
 ## Signature Verification
 
-Published packages are cryptographically signed using [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing with GitHub Actions OIDC. This lets you verify that a package was built by this repository's CI pipeline and hasn't been tampered with.
-
-### Verify a package signature
-
-```bash
-cosign verify \
-  ghcr.io/grafana/provider-grafana:v2.10.0 \
-  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
-```
-
-The same works for packages on the Upbound Marketplace:
-
-```bash
-cosign verify \
-  xpkg.upbound.io/grafana/provider-grafana:v2.10.0 \
-  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
-```
-
-### Automatic verification in Crossplane
-
-Crossplane 1.18+ supports automatic signature verification on package install via [ImageConfig](https://docs.crossplane.io/latest/packages/image-configs/#configuring-signature-verification):
-
-```yaml
-apiVersion: pkg.crossplane.io/v1beta1
-kind: ImageConfig
-metadata:
-  name: verify-provider-grafana
-spec:
-  matchImages:
-    - prefix: "ghcr.io/grafana/provider-grafana:"
-    - prefix: "xpkg.upbound.io/grafana/provider-grafana:"
-  verification:
-    provider: Cosign
-    cosign:
-      authorities:
-        - name: grafana-ci
-          keyless:
-            identities:
-              - issuer: https://token.actions.githubusercontent.com
-                subjectRegExp: https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*
-```
+Published packages are cryptographically signed. See [docs/signature-verification.md](docs/signature-verification.md) for verification instructions.
 
 ## Contributing
 

--- a/docs/signature-verification.md
+++ b/docs/signature-verification.md
@@ -1,10 +1,16 @@
 # Signature Verification
 
-Published packages are cryptographically signed using [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing with GitHub Actions OIDC. This lets you verify that a package was built by this repository's CI pipeline and hasn't been tampered with.
+Published packages are cryptographically signed and include an SBOM (software bill of materials) attestation. Both are produced using [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing with GitHub Actions OIDC. This lets you verify that a package was built by this repository's CI pipeline and hasn't been tampered with.
 
 ## How it works
 
-After each package publish, the CI pipeline signs the xpkg artifact using cosign's keyless mode. This uses the GitHub Actions OIDC identity token to obtain a short-lived certificate from Sigstore's Fulcio CA, and records the signature in Sigstore's Rekor transparency log. No long-lived signing keys are involved.
+After each package publish, the CI pipeline:
+
+1. **Signs** the xpkg artifact using cosign's keyless mode
+2. **Generates an SBOM** in SPDX format using [syft](https://github.com/anchore/syft)
+3. **Attaches the SBOM** as a signed in-toto attestation using `cosign attest`
+
+Keyless signing uses the GitHub Actions OIDC identity token to obtain a short-lived certificate from Sigstore's Fulcio CA, and records the signature in Sigstore's Rekor transparency log. No long-lived signing keys are involved.
 
 Packages are signed on both registries:
 
@@ -27,6 +33,26 @@ cosign verify \
   xpkg.upbound.io/grafana/provider-grafana:v2.10.0 \
   --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+## Verify the SBOM attestation
+
+```bash
+cosign verify-attestation \
+  ghcr.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --type spdxjson
+```
+
+To extract the SBOM contents:
+
+```bash
+cosign verify-attestation \
+  ghcr.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --type spdxjson | jq -r '.payload' | base64 -d | jq '.predicate'
 ```
 
 ## Automatic verification in Crossplane

--- a/docs/signature-verification.md
+++ b/docs/signature-verification.md
@@ -1,0 +1,56 @@
+# Signature Verification
+
+Published packages are cryptographically signed using [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing with GitHub Actions OIDC. This lets you verify that a package was built by this repository's CI pipeline and hasn't been tampered with.
+
+## How it works
+
+After each package publish, the CI pipeline signs the xpkg artifact using cosign's keyless mode. This uses the GitHub Actions OIDC identity token to obtain a short-lived certificate from Sigstore's Fulcio CA, and records the signature in Sigstore's Rekor transparency log. No long-lived signing keys are involved.
+
+Packages are signed on both registries:
+
+- `ghcr.io/grafana/provider-grafana`
+- `xpkg.upbound.io/grafana/provider-grafana`
+
+## Verify a package signature
+
+```bash
+cosign verify \
+  ghcr.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+The same works for packages on the Upbound Marketplace:
+
+```bash
+cosign verify \
+  xpkg.upbound.io/grafana/provider-grafana:v2.10.0 \
+  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+## Automatic verification in Crossplane
+
+Crossplane 1.18+ supports automatic signature verification on package install via [ImageConfig](https://docs.crossplane.io/latest/packages/image-configs/#configuring-signature-verification):
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: verify-provider-grafana
+spec:
+  matchImages:
+    - prefix: "ghcr.io/grafana/provider-grafana:"
+    - prefix: "xpkg.upbound.io/grafana/provider-grafana:"
+  verification:
+    provider: Cosign
+    cosign:
+      authorities:
+        - name: grafana-ci
+          keyless:
+            identities:
+              - issuer: https://token.actions.githubusercontent.com
+                subjectRegExp: https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*
+```
+
+If signature verification is enabled, Crossplane sets a `SignatureVerificationComplete` status condition on the `ProviderRevision` resource once verification succeeds.


### PR DESCRIPTION
## Summary

- Add cosign keyless signing to both CI workflows (`ci.yaml` and `ci_tag.yaml`)
- Sign xpkg artifacts on both registries (`xpkg.upbound.io` and `ghcr.io`) after each publish
- Add signature verification documentation to README

## How it works

After each `make publish` step, the workflow:

1. Resolves the just-pushed tag to a digest using `crane digest`
2. Signs the artifact by digest using `cosign sign --yes` (keyless mode)

Keyless signing uses the GitHub Actions OIDC identity token to obtain a short-lived certificate from Sigstore's Fulcio CA. The signature is recorded in Sigstore's Rekor transparency log. No signing keys need to be managed.

The `id-token: write` permission required for OIDC is already present on the `publish-artifacts` jobs (previously used only for Vault secret fetching).

## Verification

Consumers can verify signatures with:

```bash
cosign verify \
  ghcr.io/grafana/provider-grafana:v2.10.0 \
  --certificate-identity-regexp 'https://github.com/grafana/crossplane-provider-grafana/.github/workflows/ci.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
```

Or automatically in Crossplane 1.18+ via an `ImageConfig` resource (see README).

## Changes

- `.github/workflows/ci.yaml`: Install cosign + crane, add signing steps after Upbound and GHCR publish
- `.github/workflows/ci_tag.yaml`: Same as above
- `README.md`: Add "Signature Verification" section with `cosign verify` and `ImageConfig` examples