### PR TITLE
fix(config): handle empty id for string-typed Plugin Framework resources

### DIFF
--- a/config/groups.go
+++ b/config/groups.go
@@ -56,11 +56,20 @@ func isEmptyResourceIDDiagnostic(diags []*tfprotov6.Diagnostic) bool {
 			continue
 		}
 		msg := diag.Summary + ": " + diag.Detail
-		if !strings.Contains(msg, "parse resource ID") {
-			continue
+
+		// Int-typed and composite IDs: parsing the empty id fails.
+		if strings.Contains(msg, "parse resource ID") {
+			if strings.Contains(msg, `got ""`) ||
+				strings.Contains(msg, `id "" does not match expected format`) {
+				return true
+			}
 		}
-		if strings.Contains(msg, `got ""`) ||
-			strings.Contains(msg, `id "" does not match expected format`) {
+
+		// String-typed IDs: the empty id parses successfully as an empty
+		// string, causing the API call to hit a list endpoint instead of
+		// a get-by-id endpoint. The list endpoint returns a JSON array
+		// where a single object is expected.
+		if strings.Contains(msg, "cannot unmarshal array") {
 			return true
 		}
 	}

--- a/config/groups_test.go
+++ b/config/groups_test.go
@@ -58,6 +58,30 @@ func TestIsEmptyResourceIDDiagnostic(t *testing.T) {
 			diags: []*tfprotov6.Diagnostic{nil},
 			want:  false,
 		},
+		"string id hits list endpoint - folder": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Failed to get folder",
+				Detail:   `json: cannot unmarshal array into Go value of type models.Folder`,
+			}},
+			want: true,
+		},
+		"string id hits list endpoint - message template": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Failed to read message template",
+				Detail:   `json: cannot unmarshal array into Go value of type models.NotificationTemplate`,
+			}},
+			want: true,
+		},
+		"unmarshal array warning ignored": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityWarning,
+				Summary:  "Failed to get folder",
+				Detail:   `json: cannot unmarshal array into Go value of type models.Folder`,
+			}},
+			want: false,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Summary

Extends the `isEmptyResourceIDDiagnostic` function from #564 to also handle Plugin Framework resources with **string-typed IDs**.

- Fixes #577 (`FolderPermission`: `cannot unmarshal array into Go value of type models.Folder`)
- Fixes #565 (`MessageTemplate`: `cannot unmarshal array into Go value of type models.NotificationTemplate`)
- Also covers `DashboardPermission` (same pattern, no issue filed)

## Root Cause

PR #564 fixed the first-Observe empty-id problem for resources with **int-typed** and **composite** IDs, where parsing the empty `id` fails with a "parse resource ID" error. However, resources with **string-typed** IDs (`folder_permission`, `dashboard_permission`, `message_template`) were not covered because their `id` parses successfully as an empty string -- no parse error is produced.

Instead, the empty string propagates to the API call, e.g. `GetFolderByUID("")` sends `GET /api/folders/` which Grafana's router treats as the list endpoint, returning a JSON array where a single object is expected. This produces:

```
json: cannot unmarshal array into Go value of type models.Folder
```

## Fix

Adds a `"cannot unmarshal array"` match to `isEmptyResourceIDDiagnostic`. Since this function is applied to all resources via `ExternalNameConfigurations()`, it will also cover any resources that migrate from SDK to Plugin Framework in the future.

## Tests

Added 3 test cases to `TestIsEmptyResourceIDDiagnostic`:
- `string id hits list endpoint - folder` (the exact error from #577)
- `string id hits list endpoint - message template` (the exact error from #565)
- `unmarshal array warning ignored` (only error-severity diagnostics are matched)