### PR TITLE
fix(image): switch base image from alpine to distroless/static

### DIFF
--- a/cluster/images/provider-grafana/Dockerfile
+++ b/cluster/images/provider-grafana/Dockerfile
@@ -1,14 +1,11 @@
-FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-RUN apk --no-cache add ca-certificates bash
+FROM gcr.io/distroless/static:nonroot@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 ARG TARGETOS
 ARG TARGETARCH
 
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/provider
 
-ENV USER_ID=65532
-
-USER ${USER_ID}
+USER 65532
 EXPOSE 8080
 
 ENTRYPOINT ["provider"]


### PR DESCRIPTION
## Summary

- Replace `alpine:3.23.4` with `gcr.io/distroless/static:nonroot` as the container base image
- Eliminates busybox CVE-2025-60876 (MEDIUM, CVSS 5.4) which is 93 days past SLO with no upstream fix
- Removes unnecessary `bash` and `ca-certificates` APK packages (distroless includes ca-certs, bash was never used at runtime)

## Why this is safe

- The provider binary is fully static (`CGO_ENABLED=0`, no shared library dependencies)
- The Go code never calls `exec.Command` — no shell-outs at runtime
- `bash` was installed in the image but never used (ENTRYPOINT is the bare Go binary)
- `distroless/static` includes CA certificates needed for TLS connections to Grafana APIs
- The `nonroot` variant defaults to UID 65532, matching our existing `USER` directive

## Prior art

This matches the pattern used by other Crossplane providers:

| Provider | Base Image |
|---|---|
| provider-kubernetes | `gcr.io/distroless/static` |
| provider-helm | `gcr.io/distroless/static` |
| provider-template | `gcr.io/distroless/static` |
| crossplane core | Nix-built from scratch (no base image) |

The `alpine` base was inherited from the upjet provider template, which needs it for Terraform. Since this provider doesn't use Terraform, the Alpine dependency is unnecessary.

## Vulnerability context

Version v2.11.1 has 3 findings for CVE-2025-60876 against `busybox`, `busybox-binsh`, and `ssl_client` (all 1.37.0-r30) with no fix available. Switching to distroless eliminates the entire APK package surface area.