### PR TITLE
fix(build): upgrade crossplane CLI to v2.3.1 from cli.crossplane.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ fallthrough: submodules
 # we ensure image is present in daemon.
 xpkg.build.provider-grafana: do.build.images
 
-# NOTE(hasheddan): we ensure up is installed prior to running platform-specific
-# build steps in parallel to avoid encountering an installation race condition.
-build.init: $(CROSSPLANE_CLI)
-
 # ====================================================================================
 # Setup Terraform for fetching provider schema
 TERRAFORM := $(TOOLS_HOST_DIR)/terraform-$(TERRAFORM_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,20 @@ GO_SUBDIRS += cmd internal apis
 KIND_VERSION = v0.30.0
 UPTEST_VERSION = v2.1.0
 CRDDIFF_VERSION = v0.12.1
+# NOTE: CROSSPLANE_CLI_VERSION must be set before the include so that the := in
+# k8s_tools.mk picks up the correct version for the binary path.
+CROSSPLANE_CLI_VERSION = v2.3.1
 -include build/makelib/k8s_tools.mk
+
+# Override Crossplane CLI download target: starting from v2.3.0 the CLI moved
+# to its own repository (crossplane/cli) served from cli.crossplane.io with the
+# binary renamed from "crank" to "crossplane". The build submodule still uses
+# the old releases.crossplane.io URL which returns intermittent 403 errors.
+$(CROSSPLANE_CLI):
+	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
+	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane || $(FAIL)
+	@chmod +x $(CROSSPLANE_CLI)
+	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
 # ====================================================================================
 # Setup Images
@@ -162,7 +175,6 @@ run: go.build
 # ====================================================================================
 # End to End Testing
 CROSSPLANE_VERSION = 2.0.2
-CROSSPLANE_CLI_VERSION = v2.0.2
 CROSSPLANE_NAMESPACE = upbound-system
 
 # Auto-discover all example YAMLs for uptest; override with UPTEST_EXAMPLE_LIST env var.


### PR DESCRIPTION
## Summary

- Upgrade Crossplane CLI from v2.0.2 to v2.3.1, switching the download URL from `releases.crossplane.io` (intermittent 403s) to `cli.crossplane.io`
- Starting from v2.3.0, the CLI moved to its own repository ([crossplane/cli](https://github.com/crossplane/cli)) with the binary renamed from `crank` to `crossplane` and artifacts served from a new CDN host
- Override the download target from the build submodule since upstream ([crossplane/build](https://github.com/crossplane/build)) hasn't updated the URL yet
- Update the `build` submodule to latest upstream to pick up Crossplane 2.2 cache key support and the `xpkg.build` crossplane-cli dependency fix

## Context

The `local-deploy` job has been failing intermittently with 403 errors when downloading the CLI from `releases.crossplane.io`:
https://github.com/grafana/crossplane-provider-grafana/actions/runs/27000502299/job/79679667538

The old URL serves from S3 `STANDARD_IA` storage behind CloudFront, which is prone to transient failures under CI concurrency.