### PR TITLE
refactor(ci): always build with the latest Go patch via composite action

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,19 @@
+---
+name: Setup Go
+description: |
+  Set up Go using the minor version declared in go.mod, always resolving to
+  the latest available patch release. This decouples the active Go patch in CI
+  from the exact version pinned in go.mod (which is a minimum, not a target).
+runs:
+  using: composite
+  steps:
+    - name: Detect Go minor version from go.mod
+      id: go-minor
+      shell: bash
+      run: echo "version=$(grep -oP '^go \K[0-9]+\.[0-9]+' go.mod).x" >> "$GITHUB_OUTPUT"
+
+    - name: Setup Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: ${{ steps.go-minor.outputs.version }}
+        check-latest: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Find the Go Build Cache
         id: go
@@ -139,6 +140,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Find the Go Build Cache
         id: go
@@ -190,6 +192,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Find the Go Build Cache
         id: go
@@ -240,6 +243,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Find the Go Build Cache
         id: go
@@ -303,6 +307,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Find the Go Build Cache
         id: go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Find the Go Build Cache
         id: go
@@ -137,10 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Find the Go Build Cache
         id: go
@@ -189,10 +183,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Find the Go Build Cache
         id: go
@@ -240,10 +231,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Find the Go Build Cache
         id: go
@@ -304,10 +292,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Find the Go Build Cache
         id: go

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -73,10 +73,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -104,10 +101,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -134,10 +128,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -163,10 +154,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -236,10 +224,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
           cache: 'false'
 
       - name: Install cosign

--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -106,6 +107,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -135,6 +137,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -163,6 +166,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: 'false'
 
       - name: Vendor Dependencies
@@ -235,6 +239,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: 'false'
 
       - name: Install cosign

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Resolve version and build PR body
         id: params

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -44,10 +44,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
+        uses: ./.github/actions/setup-go
 
       - name: Resolve version and build PR body
         id: params

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/grafana/crossplane-provider-grafana/v2
 
 go 1.26.3
 
-toolchain go1.26.4
-
 require (
 	dario.cat/mergo v1.0.2
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/grafana/crossplane-provider-grafana/v2
 
-go 1.26.3
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	dario.cat/mergo v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/crossplane-provider-grafana/v2
 
-go 1.26.0
+go 1.26.3
 
 toolchain go1.26.4
 


### PR DESCRIPTION
## Summary

Make CI always build with the latest available Go patch release, without
waiting for Renovate to bump a pinned version.

## Approach

A new composite action at \`.github/actions/setup-go\` reads the minor version
from \`go.mod\`'s \`go\` directive (e.g. \`1.26\`) and invokes \`actions/setup-go\`
with \`go-version: 1.26.x\` + \`check-latest: true\`. setup-go then resolves to
the latest available patch for that minor at every run.

All 11 \`Setup Go\` steps across \`ci.yaml\`, \`ci_tag.yaml\`, and
\`update-terraform-provider.yaml\` now use the composite action.

This is the same pattern used by alertmanager and other Prometheus-ecosystem
projects (their \`quay.io/prometheus/golang-builder:1.26-base\` image and
\`go-version: 1.26.x\` setup-go usage), generalized so that the workflow
tracks \`go.mod\`'s minor version automatically.

## Effect

- **CI:** always uses the newest Go 1.26.x patch on every workflow run, instantly.
- **Minor bumps:** when \`go.mod\`'s \`go\` directive changes (e.g. to \`1.27\`),
  the workflows pick it up automatically -- no workflow edits required.
- **Local dev:** unchanged. Devs use whichever Go (\`>= go.mod\` minimum) they
  have installed; \`GOTOOLCHAIN=auto\` handles upgrades on demand.
- **Renovate:** no longer needed for Go patch updates.

## Notes on what was considered

- The \`toolchain\` directive in \`go.mod\` (with Renovate auto-merging patch
  bumps) was tried first but introduced a Renovate-scan + auto-merge delay.
- \`go-version-file: go.mod\` + \`check-latest: true\` doesn't float forward
  because setup-go reads the exact pinned version (e.g. \`1.26.3\`); \`check-latest\`
  only re-fetches that exact version.
- Setting \`go 1.26\` (no patch) in \`go.mod\` isn't stable -- \`go mod tidy\`
  rewrites it to whatever minimum the dependency tree requires.