### PR TITLE
fix(build): install Crossplane CLI in build.init and avoid parallel-make race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,18 @@ CROSSPLANE_CLI_VERSION = v2.3.1
 # to its own repository (crossplane/cli) served from cli.crossplane.io with the
 # binary renamed from "crank" to "crossplane". The build submodule still uses
 # the old releases.crossplane.io URL which returns intermittent 403 errors.
+#
+# Download to a unique temp file and rename atomically so that parallel make
+# invocations needing the same target don't race on the destination path
+# (curl exits with code 23 "Failure writing output to destination" when two
+# downloads collide on the same file).
 $(CROSSPLANE_CLI):
 	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
-	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane || $(FAIL)
-	@chmod +x $(CROSSPLANE_CLI)
+	@mkdir -p $(@D)
+	@tmp=$$(mktemp $(@D)/crossplane-cli.XXXXXX) && \
+		curl -fsSLo $$tmp https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane && \
+		chmod +x $$tmp && \
+		mv -f $$tmp $@ || $(FAIL)
 	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ $(CROSSPLANE_CLI):
 		mv -f $$tmp $@ || $(FAIL)
 	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
+# Wire `make build.init` to install the Crossplane CLI. The upstream build
+# submodule references $(CROSSPLANE_CLI) in recipe bodies (notably the
+# xpkg.release.publish.* targets) but never lists it as a prerequisite, so
+# make does not build it automatically. The publish-artifacts CI job calls
+# `make build.init` to populate tools but, without this, the CLI is missing
+# when `make publish` later tries to invoke it.
+build.init: $(CROSSPLANE_CLI)
+
 # ====================================================================================
 # Setup Images
 


### PR DESCRIPTION
## Summary

Two related issues with the Crossplane CLI install introduced in #589, both of which surface only after that PR landed:

### 1. Parallel-make race on download (affects `ci_tag.yaml` `Build Artifacts` step)

The `$(CROSSPLANE_CLI)` recipe wrote directly to the final target path with `curl -o`. When `make build.all` ran in parallel, two sub-makes could enter the recipe simultaneously, and the second `curl` failed with:

```
curl: (23) Failure writing output to destination
```

Example: https://github.com/grafana/crossplane-provider-grafana/actions/runs/27765438324 — two `installing Crossplane CLI v2.3.1` blocks start within milliseconds of each other; the first finishes `[OK]`, the second fails with code 23.

**Fix:** download into a unique `mktemp` path and atomically `mv` onto the final target. Concurrent invocations write to distinct temp files; the rename is atomic on POSIX filesystems so the destination is always either fully present or absent, never half-written.

### 2. CLI never installed in `publish-artifacts` job (affects `ci.yaml` PR runs)

The upstream build submodule references `$(CROSSPLANE_CLI)` inside recipe bodies (notably `xpkg.release.publish.*`) but never declares it as a prerequisite, so make does not build it automatically. The `publish-artifacts` job calls `make build.init` to populate tools and then `make publish`, which fails with:

```
bash: line 1: .../crossplane-cli-v2.3.1: No such file or directory
```

This has been broken for every PR since #589 merged.

**Fix:** add `$(CROSSPLANE_CLI)` as a prerequisite of `build.init` so `make build.init` actually installs the binary.
