### PR TITLE
fix(ci): set GOTOOLCHAIN=auto in setup-go composite action

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,6 +4,11 @@ description: |
   Set up Go using the minor version declared in go.mod, always resolving to
   the latest available patch release. This decouples the active Go patch in CI
   from the exact version pinned in go.mod (which is a minimum, not a target).
+
+  GOTOOLCHAIN is forced to "auto" so Go downloads a newer toolchain on demand
+  when a dependency's go.mod requires a patch newer than the one setup-go
+  installed (setup-go otherwise exports GOTOOLCHAIN=local, which fails the
+  build instead of upgrading).
 runs:
   using: composite
   steps:
@@ -17,3 +22,7 @@ runs:
       with:
         go-version: ${{ steps.go-minor.outputs.version }}
         check-latest: true
+
+    - name: Allow on-demand Go toolchain upgrades
+      shell: bash
+      run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Forces `GOTOOLCHAIN=auto` in the `setup-go` composite action so Go can download a newer toolchain on demand.

## Problem

`actions/setup-go` exports `GOTOOLCHAIN=local`, which pins builds to the installed Go and forbids automatic toolchain downloads. When an upstream dependency's `go.mod` requires a patch newer than the one setup-go installed, `go get`/`go mod tidy` fails instead of upgrading.

This broke the [update-terraform-provider](https://github.com/grafana/crossplane-provider-grafana/actions/runs/27759598355) workflow updating to `v4.39.0`:

```
go: github.com/grafana/terraform-provider-grafana/v4@v4.39.0 requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
```

#597 made CI float to the latest Go patch via `check-latest: true`, but there is a lag between an upstream dependency requiring a brand-new patch and setup-go's version manifest offering it. During that window `GOTOOLCHAIN=local` turns the lag into a hard failure.

## Fix

Append `GOTOOLCHAIN=auto` to `$GITHUB_ENV` after setup-go runs, so Go downloads the required toolchain when a dependency demands a newer patch.

Fixes #599