### PR TITLE
feat(deps): split terraform provider update for manual intervention

### DIFF
--- a/.github/workflows/templates/update-terraform-provider-intervention.md
+++ b/.github/workflows/templates/update-terraform-provider-intervention.md
@@ -1,0 +1,19 @@
+## ⚠️ Manual intervention required
+
+The automated generation steps did not complete successfully. This PR
+contains the version bump commit and any partial generated output.
+Please check out the branch, resolve the issues, and push additional
+commits before merging.
+
+**Failed steps:**
+${FAILED_STEPS}
+
+Common cause: a new resource category was added upstream, which makes
+`make generate` panic. Add an entry to `categoryConfig` in
+[config/groups.go](https://github.com/grafana/crossplane-provider-grafana/blob/main/config/groups.go).
+See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance.
+
+**Workflow run**: ${RUN_URL}
+
+---
+

--- a/.github/workflows/templates/update-terraform-provider-pr-body.md
+++ b/.github/workflows/templates/update-terraform-provider-pr-body.md
@@ -1,0 +1,8 @@
+## Automated dependency update
+
+Updates `terraform-provider-grafana` to ${VERSION}.
+
+**Release**: https://github.com/grafana/terraform-provider-grafana/releases/tag/${VERSION}
+${CHANGELOG_SECTION}
+---
+*This PR was automatically created by the [update-terraform-provider](https://github.com/grafana/crossplane-provider-grafana/actions/workflows/update-terraform-provider.yaml) workflow.*

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -52,6 +52,7 @@ jobs:
           DISPATCH_VERSION: ${{ github.event.client_payload.version }}
           DISPATCH_CHANGELOG: ${{ github.event.client_payload.changelog }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          TEMPLATE: .github/workflows/templates/update-terraform-provider-pr-body.md
         run: |
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
             version="$DISPATCH_VERSION"
@@ -69,24 +70,15 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "branch=automated/update-terraform-provider-${version}" >> "$GITHUB_OUTPUT"
 
-          # Build the base PR body. A "manual intervention" section is prepended
-          # later if go mod tidy or make generate fail.
-          {
-            echo "## Automated dependency update"
-            echo ""
-            echo "Updates \`terraform-provider-grafana\` to ${version}."
-            echo ""
-            echo "**Release**: https://github.com/grafana/terraform-provider-grafana/releases/tag/${version}"
-            if [ -n "$changelog" ]; then
-              echo ""
-              echo "### Changelog"
-              echo ""
-              echo "$changelog"
-            fi
-            echo ""
-            echo "---"
-            echo "*This PR was automatically created by the [update-terraform-provider](https://github.com/grafana/crossplane-provider-grafana/actions/workflows/update-terraform-provider.yaml) workflow.*"
-          } > /tmp/pr-body-base.md
+          # Render the base PR body from the template. A "manual intervention"
+          # section is prepended later if go mod tidy or make generate fail.
+          changelog_section=""
+          if [ -n "$changelog" ]; then
+            changelog_section=$(printf '\n### Changelog\n\n%s\n\n' "$changelog")
+          fi
+
+          export VERSION="$version" CHANGELOG_SECTION="$changelog_section"
+          envsubst '${VERSION} ${CHANGELOG_SECTION}' < "$TEMPLATE" > /tmp/pr-body-base.md
 
       # Commit 1: bump the dependency version only. This commit always succeeds
       # so that a branch and PR can be created even when later steps fail.
@@ -148,37 +140,26 @@ jobs:
           TIDY_OUTCOME: ${{ steps.tidy.outcome }}
           GENERATE_OUTCOME: ${{ steps.generate.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TEMPLATE: .github/workflows/templates/update-terraform-provider-intervention.md
         run: |
           needs_intervention=false
-          {
-            if [ "$TIDY_OUTCOME" = "failure" ] || [ "$GENERATE_OUTCOME" = "failure" ]; then
-              needs_intervention=true
-              echo "## ⚠️ Manual intervention required"
-              echo ""
-              echo "The automated generation steps did not complete successfully. This PR"
-              echo "contains the version bump commit and any partial generated output."
-              echo "Please check out the branch, resolve the issues, and push additional"
-              echo "commits before merging."
-              echo ""
-              echo "**Failed steps:**"
-              if [ "$TIDY_OUTCOME" = "failure" ]; then
-                echo "- \`go mod tidy\`"
-              fi
-              if [ "$GENERATE_OUTCOME" = "failure" ]; then
-                echo "- \`make submodules && make generate\`"
-              fi
-              echo ""
-              echo "Common cause: a new resource category was added upstream, which makes"
-              echo "\`make generate\` panic. Add an entry to \`categoryConfig\` in"
-              echo "[config/groups.go](https://github.com/grafana/crossplane-provider-grafana/blob/main/config/groups.go)."
-              echo "See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance."
-              echo ""
-              echo "**Workflow run**: ${RUN_URL}"
-              echo ""
-              echo "---"
-              echo ""
+          : > /tmp/pr-body.md
+
+          if [ "$TIDY_OUTCOME" = "failure" ] || [ "$GENERATE_OUTCOME" = "failure" ]; then
+            needs_intervention=true
+
+            failed_steps=""
+            if [ "$TIDY_OUTCOME" = "failure" ]; then
+              failed_steps="${failed_steps}- \`go mod tidy\`"$'\n'
             fi
-          } > /tmp/pr-body.md
+            if [ "$GENERATE_OUTCOME" = "failure" ]; then
+              failed_steps="${failed_steps}- \`make submodules && make generate\`"$'\n'
+            fi
+
+            export RUN_URL FAILED_STEPS="$failed_steps"
+            envsubst '${RUN_URL} ${FAILED_STEPS}' < "$TEMPLATE" > /tmp/pr-body.md
+          fi
+
           cat /tmp/pr-body-base.md >> /tmp/pr-body.md
 
           echo "needs_intervention=${needs_intervention}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           egress-policy: audit
 
-      # Use a GitHub App token so the PR commit triggers CI workflows.
+      # Use a GitHub App token so the PR commits trigger CI workflows.
       # Commits made with GITHUB_TOKEN do not trigger pull_request events.
       # Prerequisites:
       #   - The terraform-provider-grafana GitHub App must be installed on this repo
@@ -67,8 +67,10 @@ jobs:
           fi
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "branch=automated/update-terraform-provider-${version}" >> "$GITHUB_OUTPUT"
 
-          # Build PR body with changelog when available
+          # Build the base PR body. A "manual intervention" section is prepended
+          # later if go mod tidy or make generate fail.
           {
             echo "## Automated dependency update"
             echo ""
@@ -84,35 +86,136 @@ jobs:
             echo ""
             echo "---"
             echo "*This PR was automatically created by the [update-terraform-provider](https://github.com/grafana/crossplane-provider-grafana/actions/workflows/update-terraform-provider.yaml) workflow.*"
-          } > /tmp/pr-body.md
+          } > /tmp/pr-body-base.md
 
-      - name: Update dependency
+      # Commit 1: bump the dependency version only. This commit always succeeds
+      # so that a branch and PR can be created even when later steps fail.
+      - name: Commit version bump
         env:
           VERSION: ${{ steps.params.outputs.version }}
+          BRANCH: ${{ steps.params.outputs.branch }}
         run: |
-          go get "github.com/grafana/terraform-provider-grafana/v4@${VERSION}"
-          go mod tidy
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
+          git checkout -B "$BRANCH"
+
+          go get "github.com/grafana/terraform-provider-grafana/v4@${VERSION}"
+
+          git add go.mod go.sum
+          git commit -m "feat(deps): update terraform-provider-grafana to ${VERSION}"
+
+      # May fail (e.g. dependency resolution issues). Recorded, not fatal.
+      - name: Run go mod tidy
+        id: tidy
+        continue-on-error: true
+        run: go mod tidy
+
+      # May fail: make generate panics when a new resource category was added
+      # upstream (see docs/contributing.md#update-resources). Recorded, not fatal.
       - name: Run make submodules and generate
+        id: generate
+        continue-on-error: true
         run: |
           make submodules
           make generate
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
-        with:
-          token: ${{ steps.app_token.outputs.token }}
-          title: 'feat(deps): update terraform-provider-grafana to ${{ steps.params.outputs.version }}'
-          commit-message: 'feat(deps): update terraform-provider-grafana to ${{ steps.params.outputs.version }}'
-          body-path: /tmp/pr-body.md
-          branch: automated/update-terraform-provider-${{ steps.params.outputs.version }}
-          delete-branch: true
-          committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
-          author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+      # Commit 2: the regenerated output. Skipped gracefully when there is
+      # nothing to commit (e.g. generation failed before producing changes).
+      - name: Commit generated output
+        env:
+          VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No generated changes to commit."
+          else
+            git commit -m "chore(deps): regenerate resources for terraform-provider-grafana ${VERSION}"
+          fi
 
-  # Open a GitHub issue if the update job fails so the team is aware.
-  # Common failure: make generate panics when a new resource category was
-  # added upstream (see docs/contributing.md#update-resources).
+      # Push the branch regardless of go mod tidy / make generate outcomes so a
+      # human can intervene on top of the automated commits.
+      - name: Push branch
+        env:
+          BRANCH: ${{ steps.params.outputs.branch }}
+        run: git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
+
+      # Prepend a manual-intervention notice to the PR body when a step failed,
+      # and decide whether the PR should be opened as a draft.
+      - name: Compose PR body
+        id: body
+        env:
+          TIDY_OUTCOME: ${{ steps.tidy.outcome }}
+          GENERATE_OUTCOME: ${{ steps.generate.outcome }}
+        run: |
+          needs_intervention=false
+          {
+            if [ "$TIDY_OUTCOME" = "failure" ] || [ "$GENERATE_OUTCOME" = "failure" ]; then
+              needs_intervention=true
+              echo "## ⚠️ Manual intervention required"
+              echo ""
+              echo "The automated generation steps did not complete successfully. This PR"
+              echo "contains the version bump commit and any partial generated output."
+              echo "Please check out the branch, resolve the issues, and push additional"
+              echo "commits before merging."
+              echo ""
+              echo "**Failed steps:**"
+              if [ "$TIDY_OUTCOME" = "failure" ]; then
+                echo "- \`go mod tidy\`"
+              fi
+              if [ "$GENERATE_OUTCOME" = "failure" ]; then
+                echo "- \`make submodules && make generate\`"
+              fi
+              echo ""
+              echo "Common cause: a new resource category was added upstream, which makes"
+              echo "\`make generate\` panic. Add an entry to \`categoryConfig\` in"
+              echo "[config/groups.go](https://github.com/grafana/crossplane-provider-grafana/blob/main/config/groups.go)."
+              echo "See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance."
+              echo ""
+              echo "---"
+              echo ""
+            fi
+          } > /tmp/pr-body.md
+          cat /tmp/pr-body-base.md >> /tmp/pr-body.md
+
+          echo "needs_intervention=${needs_intervention}" >> "$GITHUB_OUTPUT"
+
+      # Always create the PR (idempotent) so a human can build on top of it.
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          VERSION: ${{ steps.params.outputs.version }}
+          BRANCH: ${{ steps.params.outputs.branch }}
+          NEEDS_INTERVENTION: ${{ steps.body.outputs.needs_intervention }}
+        run: |
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "PR #${existing} already exists for ${BRANCH}, updating body."
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file /tmp/pr-body.md
+            if [ "$NEEDS_INTERVENTION" = "true" ]; then
+              gh pr ready "$existing" --repo "$GITHUB_REPOSITORY" --undo || true
+            fi
+            exit 0
+          fi
+
+          draft_flag=""
+          if [ "$NEEDS_INTERVENTION" = "true" ]; then
+            draft_flag="--draft"
+          fi
+
+          gh pr create --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$BRANCH" \
+            --title "feat(deps): update terraform-provider-grafana to ${VERSION}" \
+            --body-file /tmp/pr-body.md \
+            $draft_flag
+
+  # Catastrophic fallback: only fires when the automated flow failed before a PR
+  # could be created (e.g. go get or the branch push failed). When generation
+  # steps fail but a PR is produced, the PR itself carries the intervention
+  # notice and no issue is opened.
   notify-on-failure:
     runs-on: ubuntu-24.04
     needs: update-provider
@@ -139,11 +242,9 @@ jobs:
           gh issue create --repo "$GITHUB_REPOSITORY" \
             --title "Automated terraform-provider-grafana update to ${VERSION} failed" \
             --label "automated-update-failure" \
-            --body "The [update-terraform-provider](${RUN_URL}) workflow failed while trying to update \`terraform-provider-grafana\` to \`${VERSION}\`.
+            --body "The [update-terraform-provider](${RUN_URL}) workflow failed before it could open a pull request for \`terraform-provider-grafana\` \`${VERSION}\`.
 
-          This likely requires manual intervention — common causes include:
-          - A new resource category was added upstream (requires adding an entry to \`categoryConfig\` in \`groups.go\`)
-          - Breaking API changes in the provider
+          No PR was created, so manual action is required. This usually means an early step (dependency resolution or branch push) failed.
 
           See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance.
 

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -97,24 +97,28 @@ jobs:
           git add go.mod go.sum
           git commit -m "feat(deps): update terraform-provider-grafana to ${VERSION}"
 
-      # May fail (e.g. dependency resolution issues). Recorded, not fatal.
+      # May fail (e.g. dependency resolution issues). On failure we stop the
+      # generation pipeline and open the PR with just the version bump commit.
       - name: Run go mod tidy
         id: tidy
         continue-on-error: true
         run: go mod tidy
 
-      # May fail: make generate panics when a new resource category was added
-      # upstream (see docs/contributing.md#update-resources). Recorded, not fatal.
+      # Only run when go mod tidy succeeded; running it on a broken module would
+      # just produce noise. May fail: make generate panics when a new resource
+      # category was added upstream (see docs/contributing.md#update-resources).
       - name: Run make submodules and generate
         id: generate
+        if: steps.tidy.outcome == 'success'
         continue-on-error: true
         run: |
           make submodules
           make generate
 
-      # Commit 2: the regenerated output. Skipped gracefully when there is
-      # nothing to commit (e.g. generation failed before producing changes).
+      # Commit 2: the regenerated output. Only when both go mod tidy and
+      # generation succeeded. Skipped gracefully when there is nothing to commit.
       - name: Commit generated output
+        if: steps.tidy.outcome == 'success' && steps.generate.outcome == 'success'
         env:
           VERSION: ${{ steps.params.outputs.version }}
         run: |
@@ -133,7 +137,9 @@ jobs:
         run: git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
 
       # Prepend a manual-intervention notice to the PR body when a step failed,
-      # and decide whether the PR should be opened as a draft.
+      # and decide whether the PR should be opened as a draft. When go mod tidy
+      # fails, make generate is skipped (outcome != 'success'), so only the
+      # failed steps that actually ran are listed.
       - name: Compose PR body
         id: body
         env:
@@ -145,14 +151,13 @@ jobs:
           needs_intervention=false
           : > /tmp/pr-body.md
 
-          if [ "$TIDY_OUTCOME" = "failure" ] || [ "$GENERATE_OUTCOME" = "failure" ]; then
+          if [ "$TIDY_OUTCOME" != "success" ] || [ "$GENERATE_OUTCOME" != "success" ]; then
             needs_intervention=true
 
             failed_steps=""
             if [ "$TIDY_OUTCOME" = "failure" ]; then
-              failed_steps="${failed_steps}- \`go mod tidy\`"$'\n'
-            fi
-            if [ "$GENERATE_OUTCOME" = "failure" ]; then
+              failed_steps="${failed_steps}- \`go mod tidy\` failed; \`make submodules && make generate\` was skipped"$'\n'
+            elif [ "$GENERATE_OUTCOME" = "failure" ]; then
               failed_steps="${failed_steps}- \`make submodules && make generate\`"$'\n'
             fi
 

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -147,6 +147,7 @@ jobs:
         env:
           TIDY_OUTCOME: ${{ steps.tidy.outcome }}
           GENERATE_OUTCOME: ${{ steps.generate.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           needs_intervention=false
           {
@@ -171,6 +172,8 @@ jobs:
               echo "\`make generate\` panic. Add an entry to \`categoryConfig\` in"
               echo "[config/groups.go](https://github.com/grafana/crossplane-provider-grafana/blob/main/config/groups.go)."
               echo "See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance."
+              echo ""
+              echo "**Workflow run**: ${RUN_URL}"
               echo ""
               echo "---"
               echo ""

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -186,6 +186,9 @@ jobs:
             if [ "$NEEDS_INTERVENTION" = "true" ]; then
               gh pr ready "$existing" --repo "$GITHUB_REPOSITORY" --undo || true
             fi
+            # Re-request team review; ignored if already requested or reviewed.
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --add-reviewer "grafana/platform-monitoring" || true
             exit 0
           fi
 
@@ -194,11 +197,14 @@ jobs:
             draft_flag="--draft"
           fi
 
+          # Request a review from the platform-monitoring team so they are looped
+          # in on every update PR, including drafts that need intervention.
           gh pr create --repo "$GITHUB_REPOSITORY" \
             --base main \
             --head "$BRANCH" \
             --title "feat(deps): update terraform-provider-grafana to ${VERSION}" \
             --body-file /tmp/pr-body.md \
+            --reviewer "grafana/platform-monitoring" \
             $draft_flag
 
   # Catastrophic fallback: only fires when the automated flow failed before a PR

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,13 +93,14 @@ workflow:
 
 1. Bumps the provider version and commits the `go.mod`/`go.sum` change.
 2. Runs `go mod tidy`.
-3. Runs `make submodules && make generate`.
-4. Commits the regenerated output.
+3. Runs `make submodules && make generate` (only if `go mod tidy` succeeded).
+4. Commits the regenerated output (only if both previous steps succeeded).
 5. Opens a pull request on the
    `automated/update-terraform-provider-<version>` branch.
 
 The PR is **always** created, even when steps 2-4 fail, so that a human can
-fix things up on top of the automated commits.
+fix things up on top of the automated commits. If `go mod tidy` fails,
+generation is skipped and the PR contains only the version bump commit.
 
 #### When manual intervention is required
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,7 +96,8 @@ workflow:
 3. Runs `make submodules && make generate` (only if `go mod tidy` succeeded).
 4. Commits the regenerated output (only if both previous steps succeeded).
 5. Opens a pull request on the
-   `automated/update-terraform-provider-<version>` branch.
+   `automated/update-terraform-provider-<version>` branch and requests a
+   review from the `@grafana/platform-monitoring` team.
 
 The PR is **always** created, even when steps 2-4 fail, so that a human can
 fix things up on top of the automated commits. If `go mod tidy` fails,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,10 +80,57 @@ renamed to `folder_uid`. Update your compositions and claims accordingly.
 
 ## Update resources
 
-Steps to update resources from the latest Terraform provider version:
+Resources are regenerated from the upstream Terraform provider whenever its
+version changes.
 
-> **Note:** Renovate will generally update the Terraform provider dependency
-> automatically, so there is no need to do this manually in normal circumstances.
+### Automated updates
+
+The [update-terraform-provider](../.github/workflows/update-terraform-provider.yaml)
+workflow handles updates automatically. It is triggered when a new
+`terraform-provider-grafana` release is published (via `repository_dispatch`)
+and can also be run manually from the Actions tab with a version input. The
+workflow:
+
+1. Bumps the provider version and commits the `go.mod`/`go.sum` change.
+2. Runs `go mod tidy`.
+3. Runs `make submodules && make generate`.
+4. Commits the regenerated output.
+5. Opens a pull request on the
+   `automated/update-terraform-provider-<version>` branch.
+
+The PR is **always** created, even when steps 2-4 fail, so that a human can
+fix things up on top of the automated commits.
+
+#### When manual intervention is required
+
+If `go mod tidy` or `make generate` fails, the PR is opened **as a draft** with
+a "⚠️ Manual intervention required" section describing which step failed and a
+link to the workflow run. Look for the open draft PR on the
+`automated/update-terraform-provider-<version>` branch.
+
+To resolve it, check out the branch, fix the issue, and push additional
+commits, then mark the PR ready for review:
+
+```console
+git fetch origin
+git checkout automated/update-terraform-provider-<version>
+# fix the issue (see manual steps below), then:
+make submodules && make generate
+git commit -am "fix generated resources"
+git push
+```
+
+The most common cause is a new resource category added upstream, which makes
+`make generate` panic with a message telling you to add an entry to
+`categoryConfig` in [groups.go](../config/groups.go).
+
+If the workflow fails *before* a PR can be created (e.g. dependency resolution
+or the branch push fails), it opens a GitHub issue labeled
+`automated-update-failure` instead.
+
+### Manual updates
+
+If you need to update resources by hand:
 
 1. Update the Terraform provider version in the [go.mod](../go.mod) file.
 2. Generate the resources:


### PR DESCRIPTION
## Summary

Restructures the `update-terraform-provider` workflow so a branch and PR are **always** created, even when the generation steps fail. Previously, a single job ran everything and only opened a failure issue when something broke — leaving nothing for a human to build on. Now a human can push fixes (e.g. a new `categoryConfig` entry) on top of the automated commits.

## Changes

- **Commit 1 — version bump**: `go get` the new provider version and commit `go.mod`/`go.sum`. Always succeeds.
- **`go mod tidy`** runs next. If it fails, the generation pipeline is stopped (`make generate` is skipped) so the PR ends up with just the version bump commit.
- **`make submodules && make generate`** runs only when `go mod tidy` succeeded.
- **Commit 2 — generated output**: only when both `go mod tidy` and generation succeeded; skipped gracefully when there's nothing to commit.
- **Push + PR always happen**: the branch is force-pushed and a PR is opened idempotently. When `go mod tidy` or `make generate` failed, the PR is opened as a **draft** with a `⚠️ Manual intervention required` section prepended to the body, pointing at `config/groups.go` / `docs/contributing.md#update-resources` and linking to the failed workflow run.
- **`notify-on-failure`** is reduced to a catastrophic fallback that only opens an issue when no PR could be created (e.g. `go get` or branch push failed).
- **PR body templates**: the automated PR body and the manual-intervention notice live in `.github/workflows/templates/` and are rendered with `envsubst`, keeping the workflow readable.
- **Docs**: `docs/contributing.md` documents the automated flow, the always-created PR, the draft-PR + manual-intervention path (including the `automated/update-terraform-provider-<version>` branch pattern), and the catastrophic-failure issue.

### Behavior

| `go mod tidy` | `make generate` | Commit 2 | Resulting PR |
|---|---|---|---|
| success | success | yes | normal PR, 2 commits |
| failure | skipped | no | draft PR, version bump only |
| success | failure | no | draft PR, version bump only |

## Notes

Switched from `peter-evans/create-pull-request` to explicit `git` commits + `gh pr create` to produce the two-commit history and to allow the PR to be created even when generation fails. The GitHub App token is still used so PR commits trigger CI.