### PR TITLE
fix(deps): create verified commits in update-terraform-provider workflow

### DIFF
--- a/.github/workflows/scripts/create-signed-commit.sh
+++ b/.github/workflows/scripts/create-signed-commit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Create a verified (signed) commit on a remote branch from the staged changes
+# in the working tree, using GitHub's createCommitOnBranch GraphQL mutation.
+#
+# Commits created through the API with a GitHub App / Actions token are signed
+# by GitHub and therefore satisfy branch rules that require verified signatures
+# (which plain `git push` of locally-created commits does not).
+#
+# After the remote branch is advanced, the local branch is reset to match it so
+# subsequent steps continue from the signed commit.
+#
+# Usage:
+#   create-signed-commit.sh <branch> <commit-message>
+#
+# Requirements:
+#   - GH_TOKEN must be set to a token that can write to the repo.
+#   - GITHUB_REPOSITORY must be set (owner/repo).
+#   - Changes to include must already be staged with `git add`.
+#
+# Exit status:
+#   0  commit created (or nothing staged, in which case it is a no-op)
+#   1  an error occurred
+set -euo pipefail
+
+branch="${1:?branch required}"
+message="${2:?commit message required}"
+
+owner="${GITHUB_REPOSITORY%%/*}"
+repo="${GITHUB_REPOSITORY##*/}"
+
+# Collect staged additions/modifications and deletions separately.
+mapfile -t changed < <(git diff --cached --name-only --diff-filter=ACMR)
+mapfile -t deleted < <(git diff --cached --name-only --diff-filter=D)
+
+if [ "${#changed[@]}" -eq 0 ] && [ "${#deleted[@]}" -eq 0 ]; then
+  echo "Nothing staged; skipping commit."
+  exit 0
+fi
+
+# Build the FileChanges object as JSON: { additions: [...], deletions: [...] }.
+additions="[]"
+for path in "${changed[@]}"; do
+  contents=$(base64 -w0 "$path")
+  additions=$(jq -c --arg p "$path" --arg c "$contents" \
+    '. += [{path: $p, contents: $c}]' <<<"$additions")
+done
+
+deletions="[]"
+for path in "${deleted[@]}"; do
+  deletions=$(jq -c --arg p "$path" '. += [{path: $p}]' <<<"$deletions")
+done
+
+file_changes=$(jq -cn --argjson a "$additions" --argjson d "$deletions" \
+  '{additions: $a, deletions: $d}')
+
+# The mutation requires the current head OID of the branch as an optimistic lock.
+head_oid=$(git rev-parse HEAD)
+
+# $input here is a GraphQL variable, not a shell variable; keep single quotes.
+# shellcheck disable=SC2016
+mutation='mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) { commit { oid url } }
+}'
+
+input=$(jq -cn \
+  --arg repo "${owner}/${repo}" \
+  --arg branch "refs/heads/${branch}" \
+  --arg oid "$head_oid" \
+  --arg headline "$message" \
+  --argjson changes "$file_changes" \
+  '{
+    branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+    expectedHeadOid: $oid,
+    message: {headline: $headline},
+    fileChanges: $changes
+  }')
+
+new_oid=$(gh api graphql -f query="$mutation" -F input="$input" \
+  --jq '.data.createCommitOnBranch.commit.oid')
+
+echo "Created signed commit ${new_oid} on ${branch}."
+
+# Sync the local branch to the new remote commit so later steps build on it.
+git fetch origin "$branch"
+git reset --hard "$new_oid"

--- a/.github/workflows/update-terraform-provider.yaml
+++ b/.github/workflows/update-terraform-provider.yaml
@@ -80,27 +80,53 @@ jobs:
           export VERSION="$version" CHANGELOG_SECTION="$changelog_section"
           envsubst '${VERSION} ${CHANGELOG_SECTION}' < "$TEMPLATE" > /tmp/pr-body-base.md
 
+      # Create the remote branch at the current base commit so that
+      # createCommitOnBranch has a ref to commit onto. Commits are then created
+      # via the GitHub API (see create-signed-commit.sh) so they are verified;
+      # plain `git push` of locally-created commits would fail branch rules that
+      # require signed commits.
+      #
+      # If the branch already exists (e.g. a re-run, or a human is iterating on
+      # it), it is left untouched and the automated commit steps are skipped so
+      # we never clobber existing work. The PR step still re-requests review.
+      - name: Prepare branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          BRANCH: ${{ steps.params.outputs.branch }}
+        run: |
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            echo "Branch ${BRANCH} already exists; skipping automated commits."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_oid=$(git rev-parse HEAD)
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/heads/${BRANCH}" -f sha="$base_oid" >/dev/null
+          git checkout -B "$BRANCH"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
       # Commit 1: bump the dependency version only. This commit always succeeds
       # so that a branch and PR can be created even when later steps fail.
       - name: Commit version bump
+        if: steps.branch.outputs.exists == 'false'
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ steps.params.outputs.version }}
           BRANCH: ${{ steps.params.outputs.branch }}
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
-          git checkout -B "$BRANCH"
-
           go get "github.com/grafana/terraform-provider-grafana/v4@${VERSION}"
 
           git add go.mod go.sum
-          git commit -m "feat(deps): update terraform-provider-grafana to ${VERSION}"
+          ./.github/workflows/scripts/create-signed-commit.sh "$BRANCH" \
+            "feat(deps): update terraform-provider-grafana to ${VERSION}"
 
       # May fail (e.g. dependency resolution issues). On failure we stop the
       # generation pipeline and open the PR with just the version bump commit.
       - name: Run go mod tidy
         id: tidy
+        if: steps.branch.outputs.exists == 'false'
         continue-on-error: true
         run: go mod tidy
 
@@ -109,7 +135,7 @@ jobs:
       # category was added upstream (see docs/contributing.md#update-resources).
       - name: Run make submodules and generate
         id: generate
-        if: steps.tidy.outcome == 'success'
+        if: steps.branch.outputs.exists == 'false' && steps.tidy.outcome == 'success'
         continue-on-error: true
         run: |
           make submodules
@@ -118,23 +144,32 @@ jobs:
       # Commit 2: the regenerated output. Only when both go mod tidy and
       # generation succeeded. Skipped gracefully when there is nothing to commit.
       - name: Commit generated output
-        if: steps.tidy.outcome == 'success' && steps.generate.outcome == 'success'
+        if: steps.branch.outputs.exists == 'false' && steps.tidy.outcome == 'success' && steps.generate.outcome == 'success'
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ steps.params.outputs.version }}
+          BRANCH: ${{ steps.params.outputs.branch }}
         run: |
           git add -A
-          if git diff --cached --quiet; then
-            echo "No generated changes to commit."
-          else
-            git commit -m "chore(deps): regenerate resources for terraform-provider-grafana ${VERSION}"
-          fi
+          ./.github/workflows/scripts/create-signed-commit.sh "$BRANCH" \
+            "chore(deps): regenerate resources for terraform-provider-grafana ${VERSION}"
 
-      # Push the branch regardless of go mod tidy / make generate outcomes so a
-      # human can intervene on top of the automated commits.
-      - name: Push branch
+      # When the branch already existed we leave it (and any open PR) untouched
+      # beyond re-requesting review, so we never overwrite in-progress work.
+      - name: Re-request review on existing PR
+        if: steps.branch.outputs.exists == 'true'
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           BRANCH: ${{ steps.params.outputs.branch }}
-        run: git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
+        run: |
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --add-reviewer "grafana/platform-monitoring" || true
+          else
+            echo "Branch ${BRANCH} exists but has no open PR; leaving as-is."
+          fi
 
       # Prepend a manual-intervention notice to the PR body when a step failed,
       # and decide whether the PR should be opened as a draft. When go mod tidy
@@ -142,6 +177,7 @@ jobs:
       # failed steps that actually ran are listed.
       - name: Compose PR body
         id: body
+        if: steps.branch.outputs.exists == 'false'
         env:
           TIDY_OUTCOME: ${{ steps.tidy.outcome }}
           GENERATE_OUTCOME: ${{ steps.generate.outcome }}
@@ -169,29 +205,15 @@ jobs:
 
           echo "needs_intervention=${needs_intervention}" >> "$GITHUB_OUTPUT"
 
-      # Always create the PR (idempotent) so a human can build on top of it.
+      # Create the PR for the freshly created branch.
       - name: Create pull request
+        if: steps.branch.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ steps.params.outputs.version }}
           BRANCH: ${{ steps.params.outputs.branch }}
           NEEDS_INTERVENTION: ${{ steps.body.outputs.needs_intervention }}
         run: |
-          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-            --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
-
-          if [ -n "$existing" ]; then
-            echo "PR #${existing} already exists for ${BRANCH}, updating body."
-            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file /tmp/pr-body.md
-            if [ "$NEEDS_INTERVENTION" = "true" ]; then
-              gh pr ready "$existing" --repo "$GITHUB_REPOSITORY" --undo || true
-            fi
-            # Re-request team review; ignored if already requested or reviewed.
-            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
-              --add-reviewer "grafana/platform-monitoring" || true
-            exit 0
-          fi
-
           draft_flag=""
           if [ "$NEEDS_INTERVENTION" = "true" ]; then
             draft_flag="--draft"
@@ -208,9 +230,9 @@ jobs:
             $draft_flag
 
   # Catastrophic fallback: only fires when the automated flow failed before a PR
-  # could be created (e.g. go get or the branch push failed). When generation
-  # steps fail but a PR is produced, the PR itself carries the intervention
-  # notice and no issue is opened.
+  # could be created (e.g. go get, branch creation, or the commit API call
+  # failed). When generation steps fail but a PR is produced, the PR itself
+  # carries the intervention notice and no issue is opened.
   notify-on-failure:
     runs-on: ubuntu-24.04
     needs: update-provider
@@ -239,7 +261,7 @@ jobs:
             --label "automated-update-failure" \
             --body "The [update-terraform-provider](${RUN_URL}) workflow failed before it could open a pull request for \`terraform-provider-grafana\` \`${VERSION}\`.
 
-          No PR was created, so manual action is required. This usually means an early step (dependency resolution or branch push) failed.
+          No PR was created, so manual action is required. This usually means an early step (dependency resolution, branch creation, or the commit API call) failed.
 
           See [docs/contributing.md#update-resources](https://github.com/grafana/crossplane-provider-grafana/blob/main/docs/contributing.md#update-resources) for guidance.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,6 +103,12 @@ The PR is **always** created, even when steps 2-4 fail, so that a human can
 fix things up on top of the automated commits. If `go mod tidy` fails,
 generation is skipped and the PR contains only the version bump commit.
 
+Commits are created through the GitHub API (via the `createCommitOnBranch`
+GraphQL mutation, see
+[scripts/create-signed-commit.sh](../.github/workflows/scripts/create-signed-commit.sh))
+so they are verified/signed, which is required by the branch rules. A plain
+`git push` of locally-created commits would be rejected.
+
 #### When manual intervention is required
 
 If `go mod tidy` or `make generate` fails, the PR is opened **as a draft** with


### PR DESCRIPTION
## Problem

After #603 merged, the `update-terraform-provider` workflow fails at the **Push branch** step:

```
Push branch — Process completed with exit code 1
```

The repo requires **verified (signed) commits**. The workflow created commits locally with `git commit` and pushed them with `git push`, but locally-created commits are unsigned and get rejected by the branch rule. (The previous `peter-evans/create-pull-request` action sidestepped this because it commits via the GitHub API, which signs commits server-side.)

## Fix

Create both commits through GitHub's `createCommitOnBranch` GraphQL mutation instead of `git push`. Commits made through the API with the app token are signed by GitHub and satisfy the branch rule.

- New helper `.github/workflows/scripts/create-signed-commit.sh` builds the `FileChanges` payload from the staged diff (additions + deletions, base64-encoded), calls the mutation, and resets the local branch to the new signed commit so later steps build on it.
- **Prepare branch** step creates the remote branch up front (via the git refs API) so the mutation has a ref to commit onto.
- If the branch **already exists** (a re-run, or a human is iterating on the draft), the automated commit steps are skipped so in-progress work is never clobbered; review is simply re-requested on the existing PR.
- Removed the old **Push branch** step.

The two-commit structure, draft-PR-on-failure behavior, and `@grafana/platform-monitoring` review request are all preserved.

## Notes

All `gh`/API calls use the app token (not `GITHUB_TOKEN`), so the job-level `contents: read` permission is not a constraint for the writes.