### PR TITLE
fix(ci): remove invalid cache input from setup-go steps

### DIFF
--- a/.github/workflows/ci_tag.yaml
+++ b/.github/workflows/ci_tag.yaml
@@ -74,7 +74,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -102,7 +101,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -129,7 +127,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -155,7 +152,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-          cache: 'false'
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -225,7 +221,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-          cache: 'false'
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
## Summary

The `Setup Go` steps in `.github/workflows/ci_tag.yaml` had a stray `cache: 'false'` line indented under `uses:` without a `with:` block. This produced an invalid workflow YAML error:

> You have an error in your yaml syntax on line 77

The `setup-go` composite action takes no inputs, so the line is removed entirely (5 occurrences).

## Notes

- Only `ci_tag.yaml` was affected; `ci.yaml` and `update-terraform-provider.yaml` were checked and are clean.
- YAML validated after the change.