### PR TITLE
fix(deps): send GraphQL input as JSON body for signed commits

### DIFF
--- a/.github/workflows/scripts/create-signed-commit.sh
+++ b/.github/workflows/scripts/create-signed-commit.sh
@@ -76,7 +76,13 @@ input=$(jq -cn \
     fileChanges: $changes
   }')
 
-new_oid=$(gh api graphql -f query="$mutation" -F input="$input" \
+# Pass the query and variables as a single JSON request body. `gh api graphql`
+# with -F cannot coerce a JSON string into a nested input object, so build the
+# full GraphQL payload ({query, variables}) and feed it on stdin via --input -.
+request=$(jq -cn --arg query "$mutation" --argjson input "$input" \
+  '{query: $query, variables: {input: $input}}')
+
+new_oid=$(gh api graphql --input - <<<"$request" \
   --jq '.data.createCommitOnBranch.commit.oid')
 
 echo "Created signed commit ${new_oid} on ${branch}."


### PR DESCRIPTION
## What

Fixes the signed-commit helper introduced in #604, which broke the `update-terraform-provider` workflow.

## Problem

`create-signed-commit.sh` called:

```sh
gh api graphql -f query="$mutation" -F input="$input"
```

This failed in CI with:

```
gh: Variable $input of type CreateCommitOnBranchInput! was provided invalid value
```

(see [run 28155884630](https://github.com/grafana/crossplane-provider-grafana/actions/runs/28155884630/job/83384233554))

`gh api graphql`'s `-F` flag cannot coerce a JSON string into a nested input object — it sends `$input` as a flat scalar, which the API rejects for the `CreateCommitOnBranchInput!` type.

## Fix

Build the full GraphQL request body (`{query, variables: {input}}`) and pass it on stdin via `gh api graphql --input -`, which correctly parses the nested input object.

## Testing

Verified end-to-end against this repo using a throwaway worktree + temporary branch: the API call now succeeds and the resulting commit is reported `verified: true` / `reason: valid` (committed by GitHub). Temporary branch was deleted afterward.
