### PR TITLE
chore: mark schemas as generated in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@ config/provider-metadata.yaml linguist-generated=true
 config/schema.json linguist-generated=true
 examples-generated/** linguist-generated=true
 package/** linguist-generated=true
+schemas/** linguist-generated=true
 zz_**.go linguist-generated=true


### PR DESCRIPTION
JSON schemas under schemas/ are produced by cmd/generate-schemas during make generate, but unlike package/** and examples-generated/** they were not marked in .gitattributes. This adds schemas/** linguist-generated=true so GitHub collapses and labels them as generated in PR diffs. 
[Proof in the docs](https://github.com/grafana/crossplane-provider-grafana/blob/f2ae150367c89030cca884eb55964ffaf01ab656/docs/kubeconform.md#how-schemas-are-generated)