### PR TITLE
test(alerting): add cloud e2e for empty ContactPoint (#607)

### DIFF
--- a/examples/cloud/v1alpha1/empty-contactpoint.yaml
+++ b/examples/cloud/v1alpha1/empty-contactpoint.yaml
@@ -1,0 +1,33 @@
+# E2E reproduction for https://github.com/grafana/crossplane-provider-grafana/issues/607
+#
+# A ContactPoint that specifies only a name and no integrations ("empty"
+# contact point). The Grafana UI allows creating such a grouping, but the
+# Grafana provisioning API (and therefore terraform-provider-grafana, which
+# this provider wraps) has no representation for a contact point with zero
+# integrations.
+#
+# In terraform-provider-grafana, ContactPoint Create == Update. The update
+# routine iterates over notifier sets only; with no integrations there is
+# nothing to POST, so no contact point is ever created. Create then sets the
+# ID and immediately re-reads, finds nothing, and clears the ID. The Terraform
+# SDK reports this as:
+#
+#   create failed: failed to read the ID of the new resource
+#
+# Expected (today): this resource never becomes Ready and surfaces the error
+# above. This example reproduces the bug; it is NOT expected to pass uptest.
+---
+apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+kind: ContactPoint
+metadata:
+  annotations:
+    uptest.upbound.io/disable-import: "true"
+    meta.upbound.io/example-id: cloud/v1alpha1/empty-contactpoint
+  name: e2e-empty-contactpoint
+  namespace: upbound-system
+spec:
+  forProvider:
+    name: e2e-empty-contactpoint
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: e2e-cloud-instance


### PR DESCRIPTION
## What

Adds a cloud e2e example reproducing [#607](https://github.com/grafana/crossplane-provider-grafana/issues/607): a `ContactPoint` with only a `name` and no integrations fails to create.

`examples/cloud/v1alpha1/empty-contactpoint.yaml`

## Reproduced error

Run against a live stack via `make e2e-cloud` (cloud creds in env):

```
Ready=False  reason=Creating
Synced=False reason=ReconcileError
  msg=create failed: failed to read the ID of the new resource
```

`GET /v1/provisioning/contact-points?name=e2e-empty-contactpoint` returns `[]` — nothing is ever created in Grafana.

## Root cause

This is inherited behavior from terraform-provider-grafana:

1. ContactPoint `Create == Update`. `updateContactPoint` only iterates **notifier sets**.
2. With zero integrations, `unpackContactPoints` returns an empty slice, so **no POST** is made to the provisioning API.
3. Create sets the ID, then re-reads; the read finds no matching contact point and clears the ID (`WarnMissing`).
4. The Terraform SDK sees an empty ID after a "successful" create and returns `failed to read the ID of the new resource`.

The Grafana provisioning API has no representation for a contact point with zero integrations (terraform enforces `AtLeastOneOf` notifier fields). The UI can show an "empty" grouping, but it cannot be provisioned.

## Notes

- This example is **not run by CI** (no e2e/uptest job in any workflow); it runs only via a manual local `make e2e-cloud`.
- It documents/reproduces the bug and is **not expected to reach `Ready`** until the underlying behavior is addressed. A full local `make e2e-cloud` will fail on it.

Closes #607