### PR TITLE
fix(release): stop git-cliff bumped-version step clobbering release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,18 +24,21 @@ jobs:
         persist-credentials: false
     - name: Unshallow
       run: git fetch --prune --unshallow
+    # git-cliff-action defaults its output file to git-cliff/CHANGELOG.md. Give each
+    # git-cliff step an explicit, distinct --output path so the --bumped-version step
+    # below does not clobber the generated changelog used for the release notes.
     - name: Generate changelog
       id: changelog
       uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
       with:
-        args: --latest --strip header
+        args: --latest --strip header --output git-cliff/RELEASE_NOTES.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Compute expected version
       id: expected_version
       uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
       with:
-        args: --bumped-version
+        args: --bumped-version --output git-cliff/bumped-version.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Validate semver bump


### PR DESCRIPTION
## Problem

The release workflow produced empty/garbage GitHub release notes.

Both `orhun/git-cliff-action` steps in `.github/workflows/release.yaml` used the action's **default output file** (`git-cliff/CHANGELOG.md`):

1. **Generate changelog** wrote the release notes to `git-cliff/CHANGELOG.md`.
2. **Compute expected version** (`--bumped-version`) ran git-cliff again with no `--output`, **overwriting** `git-cliff/CHANGELOG.md` with just the version string.
3. `ncipollo/release-action` then read `bodyFile: ${{ steps.changelog.outputs.changelog }}` — that clobbered file — so the release body was not the actual notes.

## Fix

Give each git-cliff step a distinct `--output` path so the release notes file is not overwritten:

- Generate changelog -> `git-cliff/RELEASE_NOTES.md`
- Compute expected version -> `git-cliff/bumped-version.txt`

This matches the approach already used in `terraform-provider-grafana`'s release workflow.

Note: unlike terraform-provider-grafana (GoReleaser), this repo uses `ncipollo/release-action`, so no extra copy-outside-repo/clean-dirty-tree step is needed — `bodyFile` reads the distinct output path directly.