### PR TITLE
ci(renovate): use plain deps scope for security PR titles

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -46,4 +46,13 @@
       semanticCommitType: 'fix',
     },
   ],
+  // Grafana's global Renovate config titles vulnerability fixes as
+  // "fix(security/<severity>/<cve>): ... [security]". The PR title check
+  // requires scopes to match [a-z][a-z0-9_-]*, so the slashes make every
+  // security PR fail and block automerge. Severity and CVE are already
+  // conveyed via labels and the PR body, so use a plain "deps" scope.
+  vulnerabilityAlerts: {
+    semanticCommitScope: 'deps',
+    commitMessageSuffix: '',
+  },
 }


### PR DESCRIPTION
## Problem

Grafana's global Renovate config titles vulnerability fixes as:

```
fix(security/unknown/): update module golang.org/x/mod to v0.40.0 [security]
```

The `Validate PR title` check (`.github/workflows/pr-title.yml`) only accepts scopes matching `[a-z][a-z0-9_-]*`, so the slashes make **every** security PR fail the check and block automerge.

Worse, the check is not a required status check, so `platformAutomerge` still merges the PR — and the malformed scope lands in `main`. This already happened with #657 and #648: I manually retitled both to `fix(deps): ...`, Renovate reverted the titles within ~60s, and the squash merge landed with the bad scope. See `2edb9643`.

## Change

Override the `vulnerabilityAlerts` config object to use a plain `deps` scope and drop the `[security]` suffix:

```json5
vulnerabilityAlerts: {
  semanticCommitScope: 'deps',
  commitMessageSuffix: '',
},
```

Resulting title:

```
fix(deps): update module golang.org/x/mod to v0.40.0
```

Severity and CVE are still conveyed via the `severity:*` / `automerge-security-update` labels and the PR body, which embeds the full advisory.

## Notes

- [`vulnerabilityAlerts`](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) is a mergeable config object, so this overrides only these two fields of the global config and leaves the rest (`prCreation: immediate`, `vulnerabilityFixStrategy`, etc.) intact.
- This does **not** change `branchName`, which is `{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}` and does not reference the commit scope. Existing `renovate/security-*` branches and their PRs get retitled in place rather than recreated.
- Validated with `renovate-config-validator`.

## Affected open PRs

Once merged, Renovate should retitle these on its next run: #645, #646, #647, #655.