### PR TITLE
fix(connections): treat missing scrape jobs as absent

### DIFF
--- a/config/groups.go
+++ b/config/groups.go
@@ -39,22 +39,33 @@ func KindOverrides() config.ResourceOption {
 func ExternalNameConfigurations() config.ResourceOption {
 	return func(r *config.Resource) {
 		if _, ok := GroupMap[r.Name]; ok {
-			r.ExternalName = identifierFromProviderTreatingEmptyIDAsNotFound()
+			r.ExternalName = identifierFromProviderTreatingNotFoundDiagnostics()
 		}
 	}
 }
 
-func identifierFromProviderTreatingEmptyIDAsNotFound() config.ExternalName {
+func identifierFromProviderTreatingNotFoundDiagnostics() config.ExternalName {
 	externalName := config.IdentifierFromProvider
-	externalName.IsNotFoundDiagnosticFn = isEmptyResourceIDDiagnostic
+	externalName.IsNotFoundDiagnosticFn = shouldTreatDiagnosticsAsResourceNotFound
 	return externalName
 }
 
-func isEmptyResourceIDDiagnostic(diags []*tfprotov6.Diagnostic) bool {
+func shouldTreatDiagnosticsAsResourceNotFound(diags []*tfprotov6.Diagnostic) bool {
 	for _, diag := range diags {
 		if diag == nil || diag.Severity != tfprotov6.DiagnosticSeverityError {
 			continue
 		}
+
+		// The Connections API returns ErrNotFound when a metrics endpoint
+		// scrape job does not exist. The upstream Terraform resource reports
+		// that error as a diagnostic instead of removing the resource from
+		// state. Treat this specific diagnostic as an absent remote resource so
+		// that Upjet can proceed with Create.
+		if diag.Summary == "failed to get metrics endpoint scrape job" &&
+			strings.HasSuffix(diag.Detail, ": not found") {
+			return true
+		}
+
 		msg := diag.Summary + ": " + diag.Detail
 
 		// Int-typed and composite IDs: parsing the empty id fails.

--- a/config/groups_test.go
+++ b/config/groups_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-func TestIsEmptyResourceIDDiagnostic(t *testing.T) {
+func TestShouldTreatDiagnosticsAsResourceNotFound(t *testing.T) {
+	isNotFound := identifierFromProviderTreatingNotFoundDiagnostics().IsNotFoundDiagnosticFn
+
 	cases := map[string]struct {
 		diags []*tfprotov6.Diagnostic
 		want  bool
@@ -58,6 +60,38 @@ func TestIsEmptyResourceIDDiagnostic(t *testing.T) {
 			diags: []*tfprotov6.Diagnostic{nil},
 			want:  false,
 		},
+		"metrics endpoint scrape job not found": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "failed to get metrics endpoint scrape job",
+				Detail:   `failed to get metrics endpoint scrape job "staging-smoke": not found`,
+			}},
+			want: true,
+		},
+		"metrics endpoint scrape job read failure": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "failed to get metrics endpoint scrape job",
+				Detail:   `failed to get metrics endpoint scrape job "staging-smoke": request not authorized for stack`,
+			}},
+			want: false,
+		},
+		"other resource not found": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "failed to get dashboard",
+				Detail:   `failed to get dashboard "example": not found`,
+			}},
+			want: false,
+		},
+		"metrics endpoint scrape job not found warning": {
+			diags: []*tfprotov6.Diagnostic{{
+				Severity: tfprotov6.DiagnosticSeverityWarning,
+				Summary:  "failed to get metrics endpoint scrape job",
+				Detail:   `failed to get metrics endpoint scrape job "staging-smoke": not found`,
+			}},
+			want: false,
+		},
 		"string id hits list endpoint - folder": {
 			diags: []*tfprotov6.Diagnostic{{
 				Severity: tfprotov6.DiagnosticSeverityError,
@@ -86,7 +120,7 @@ func TestIsEmptyResourceIDDiagnostic(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := isEmptyResourceIDDiagnostic(tc.diags); got != tc.want {
+			if got := isNotFound(tc.diags); got != tc.want {
 				t.Fatalf("got %t, want %t", got, tc.want)
 			}
 		})


### PR DESCRIPTION
### Description of your changes

Fixes #667:

The `grafana_connections_metrics_endpoint_scrape_job` resource treats an HTTP
404 returned by the Connections API during `Read` as a diagnostic error. A
missing remote scrape job should instead be treated as absent state.

This prevents resource creation through Crossplane/Upjet because the initial
observe operation fails before the controller can proceed to `Create`.

The fix adds a workaround to detect this case 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ SKIPPED ] Run `make reviewable test` to ensure this PR is ready for review.

`make reviewable test` generated a lot of changes to autogenerated objects (I did not include them here). It also led to an error not related to my changes:
```
16:17:34 [ .. ] golangci-lint
config/grafana/oncall.go:19:3: SA1019: (github.com/crossplane/upjet/v2/pkg/config.Reference).Type is deprecated: Type is deprecated in favor of TerraformName, which provides a more stable and less error-prone API compared to Type. TerraformName will automatically handle name & version configurations that will affect the generated cross-resource reference. This is crucial especially if the provider generates multiple versions for its MR APIs. (staticcheck)
                Type:              typePath,
                ^
1 issues:
* staticcheck: 1
16:21:20 [FAIL]
```

### How has this code been tested

1. added unit tests
2. spawned local kind cluster and tested fix via `make run` + creating a MetricsEndpointScrapeJob

[contribution process]: https://git.io/fj2m9
